### PR TITLE
fix(interactive-login): capture data immediately for manual-mode plugins

### DIFF
--- a/app.py
+++ b/app.py
@@ -202,6 +202,103 @@ def format_time_remaining(days):
             parts.append(f"{rem_days} day{'s' if rem_days != 1 else ''}")
         return ", ".join(parts) + " remaining"
 
+def _persist_fetch_result(account, provider, data):
+    """
+    Applies scraped plugin data (balance, status, expiration, certificates) to an
+    account and commits it, including the expiration-warning notification logic.
+    Shared by the manual "Sync Now" flow and the immediate post-login sync so both
+    paths compute expiration/notifications identically.
+    """
+    account.balance = data.get('balance', account.balance)
+    account.status = data.get('status', account.status)
+
+    from expiration import calculate_expiration
+    last_activity = data.get('last_activity_date')
+    scraped_exp = data.get('expiration_date')
+
+    if last_activity:
+        computed_expiration = calculate_expiration(
+            provider.plugin_name,
+            account.balance,
+            account.status,
+            last_activity,
+            account.has_exemption
+        )
+    else:
+        computed_expiration = calculate_expiration(
+            provider.plugin_name,
+            account.balance,
+            account.status,
+            scraped_exp if provider.plugin_name == 'korean' else None,
+            account.has_exemption
+        )
+        if provider.plugin_name != 'korean' and scraped_exp:
+            computed_expiration = scraped_exp
+
+    if account.has_exemption:
+        computed_expiration = None
+
+    if isinstance(computed_expiration, str):
+        try:
+            computed_expiration = datetime.fromisoformat(computed_expiration.replace('Z', '+00:00')).replace(tzinfo=None)
+        except ValueError:
+            computed_expiration = None
+
+    account.expiration_date = computed_expiration
+    account.expiration_meta = data.get('expiration_meta', {})
+
+    # Spam-filtered warning notifications
+    warning_threshold_setting = Settings.query.filter_by(key='warning_threshold').first()
+    warning_threshold_days = int(warning_threshold_setting.value) if warning_threshold_setting else 30
+
+    if computed_expiration:
+        days_left = (computed_expiration - datetime.utcnow()).days
+        if days_left <= warning_threshold_days:
+            if (account.last_notified_expiration is None or
+                    computed_expiration < account.last_notified_expiration):
+                from notifier import send_desktop_notification
+                title = f"Points Expiring Soon: {account.provider.name}"
+                message = f"Your balance of {account.balance:,} points is set to expire on {computed_expiration.strftime('%Y-%m-%d')} ({days_left} days left)!"
+                send_desktop_notification(title, message)
+                account.last_notified_expiration = computed_expiration
+        else:
+            if account.last_notified_expiration and computed_expiration > account.last_notified_expiration:
+                account.last_notified_expiration = None
+    else:
+        account.last_notified_expiration = None
+
+    account.last_fetch_status = 'SUCCESS'
+    account.last_error = None
+    account.last_updated = datetime.utcnow()
+
+    history = AccountHistory(account_id=account.id, balance=account.balance)
+    db.session.add(history)
+
+    # Sync certificates/coupons if present in parsed data
+    if 'certificates' in data:
+        scraped_certs = Certificate.query.filter_by(account_id=account.id).all()
+        for c in scraped_certs:
+            if not c.details.get('is_custom'):
+                db.session.delete(c)
+        for cert_data in data.get('certificates', []):
+            exp_date_str = cert_data.get('expiration_date')
+            exp_date = None
+            if exp_date_str:
+                try:
+                    exp_date = datetime.strptime(exp_date_str, "%Y-%m-%d")
+                except Exception:
+                    pass
+            cert = Certificate(
+                account_id=account.id,
+                name=cert_data.get('name'),
+                expiration_date=exp_date,
+                details=cert_data.get('details', {})
+            )
+            db.session.add(cert)
+
+    db.session.commit()
+    return computed_expiration
+
 def create_app(config_class=Config):
     if getattr(sys, 'frozen', False):
         template_folder = os.path.join(sys._MEIPASS, 'templates')
@@ -874,98 +971,7 @@ def create_app(config_class=Config):
                 **account.extra_metadata
             )
             
-            # Update account
-            account.balance = data.get('balance', account.balance)
-            account.status = data.get('status', account.status)
-            
-            # Dynamic expiration calculation
-            from expiration import calculate_expiration
-            last_activity = data.get('last_activity_date')
-            scraped_exp = data.get('expiration_date')
-            
-            if last_activity:
-                computed_expiration = calculate_expiration(
-                    provider.plugin_name,
-                    account.balance,
-                    account.status,
-                    last_activity,
-                    account.has_exemption
-                )
-            else:
-                computed_expiration = calculate_expiration(
-                    provider.plugin_name,
-                    account.balance,
-                    account.status,
-                    scraped_exp if provider.plugin_name == 'korean' else None,
-                    account.has_exemption
-                )
-                if provider.plugin_name != 'korean' and scraped_exp:
-                    computed_expiration = scraped_exp
-            
-            if account.has_exemption:
-                computed_expiration = None
-                
-            if isinstance(computed_expiration, str):
-                try:
-                    computed_expiration = datetime.fromisoformat(computed_expiration.replace('Z', '+00:00')).replace(tzinfo=None)
-                except ValueError:
-                    computed_expiration = None
-                    
-            account.expiration_date = computed_expiration
-            account.expiration_meta = data.get('expiration_meta', {})
-            
-            # Spam-filtered warning notifications
-            from models import Settings
-            warning_threshold_setting = Settings.query.filter_by(key='warning_threshold').first()
-            warning_threshold_days = int(warning_threshold_setting.value) if warning_threshold_setting else 30
-            
-            if computed_expiration:
-                days_left = (computed_expiration - datetime.utcnow()).days
-                if days_left <= warning_threshold_days:
-                    if (account.last_notified_expiration is None or 
-                            computed_expiration < account.last_notified_expiration):
-                        from notifier import send_desktop_notification
-                        title = f"Points Expiring Soon: {account.provider.name}"
-                        message = f"Your balance of {account.balance:,} points is set to expire on {computed_expiration.strftime('%Y-%m-%d')} ({days_left} days left)!"
-                        send_desktop_notification(title, message)
-                        account.last_notified_expiration = computed_expiration
-                else:
-                    if account.last_notified_expiration and computed_expiration > account.last_notified_expiration:
-                        account.last_notified_expiration = None
-            else:
-                account.last_notified_expiration = None
-            
-            account.last_fetch_status = 'SUCCESS'
-            account.last_error = None
-            account.last_updated = datetime.utcnow()
-            
-            # Add history
-            history = AccountHistory(account_id=account.id, balance=account.balance)
-            db.session.add(history)
-            
-            # Sync certificates/coupons if present in parsed data
-            if 'certificates' in data:
-                scraped_certs = Certificate.query.filter_by(account_id=account.id).all()
-                for c in scraped_certs:
-                    if not c.details.get('is_custom'):
-                        db.session.delete(c)
-                for cert_data in data.get('certificates', []):
-                    exp_date_str = cert_data.get('expiration_date')
-                    exp_date = None
-                    if exp_date_str:
-                        try:
-                            exp_date = datetime.strptime(exp_date_str, "%Y-%m-%d")
-                        except Exception:
-                            pass
-                    cert = Certificate(
-                        account_id=account.id,
-                        name=cert_data.get('name'),
-                        expiration_date=exp_date,
-                        details=cert_data.get('details', {})
-                    )
-                    db.session.add(cert)
-            
-            db.session.commit()
+            computed_expiration = _persist_fetch_result(account, provider, data)
             app_log.info(f"Sync successful for {account.display_name}. Balance: {account.balance}, Expiration: {computed_expiration}")
             from notifier import send_desktop_notification
             send_desktop_notification("Sync Successful", f"{account.display_name} balance updated successfully to {account.balance:,} points.")
@@ -1188,11 +1194,12 @@ def create_app(config_class=Config):
             flash(f'Plugin {provider.plugin_name} not found.')
             return redirect(url_for('index'))
 
+        password = security_manager.decrypt(account.password_encrypted)
+        profile_dir = os.path.join(app.config.get('ROOT_DIR', os.getcwd()), 'browser_profiles', str(account.id))
+
         try:
             app_log.info(f"Starting interactive login for account {account.display_name}...")
-            password = security_manager.decrypt(account.password_encrypted)
-            profile_dir = os.path.join(app.config.get('ROOT_DIR', os.getcwd()), 'browser_profiles', str(account.id))
-            safe_call_plugin_method(
+            login_result = safe_call_plugin_method(
                 plugin.interactive_login,
                 account.username,
                 password,
@@ -1203,14 +1210,48 @@ def create_app(config_class=Config):
                 **account.extra_metadata
             )
             app_log.info(f"Interactive login completed for {account.display_name}.")
-            account.last_fetch_status = "SUCCESS"
-            account.last_error = "Interactive Login succeeded. Please click 'Sync Now' to synchronize your points."
-            account.last_updated = datetime.utcnow()
-            db.session.commit()
-            flash(f'Interactive login completed for {account.display_name}. Try syncing now.')
         except Exception as e:
             app_log.error(f"Interactive login failed for {account.display_name}: {str(e)}", exc_info=True)
             flash(f'Interactive login failed for {account.display_name}: {str(e)}')
+            referrer = request.referrer
+            if referrer and ('/accounts/' in referrer) and ('/edit' not in referrer):
+                return redirect(referrer)
+            return redirect(url_for('index'))
+
+        # If the plugin already scraped data from the still-open, authenticated
+        # session (see ProviderPlugin.interactive_login), use it directly instead
+        # of launching a second browser via fetch_data() — a second launch isn't
+        # guaranteed to inherit the login, e.g. on programs that gate every login
+        # behind MFA. Plugins that can't scrape from within the login flow (e.g.
+        # manual mode using a native, non-automated browser) return None here and
+        # fall back to a normal fetch_data() call.
+        try:
+            if isinstance(login_result, dict):
+                data = login_result
+            else:
+                app_log.info(f"Fetching balance immediately after login for {account.display_name}...")
+                data = safe_call_plugin_method(
+                    plugin.fetch_data,
+                    account.username,
+                    password,
+                    profile_dir=profile_dir,
+                    _account_id=account.id,
+                    _provider_name=account.provider.name,
+                    _current_balance=account.balance,
+                    **account.extra_metadata
+                )
+            _persist_fetch_result(account, provider, data)
+            app_log.info(f"Post-login sync successful for {account.display_name}. Balance: {account.balance}")
+            from notifier import send_desktop_notification
+            send_desktop_notification("Sync Successful", f"{account.display_name} balance updated successfully to {account.balance:,} points.")
+            flash(f'{account.display_name} logged in and synced successfully.')
+        except Exception as e:
+            account.last_fetch_status = 'FAILED'
+            account.last_error = str(e)
+            account.last_updated = datetime.utcnow()
+            db.session.commit()
+            app_log.error(f"Post-login sync failed for {account.display_name}: {str(e)}", exc_info=True)
+            flash(f'Interactive login succeeded for {account.display_name}, but the immediate sync failed: {str(e)}. Try "Sync Now".')
 
         referrer = request.referrer
         if referrer and ('/accounts/' in referrer) and ('/edit' not in referrer):

--- a/plugins/base.py
+++ b/plugins/base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Optional
 from datetime import datetime
 import time
 import inspect
@@ -771,9 +771,20 @@ class ProviderPlugin(ABC):
         pass
 
     @abstractmethod
-    def interactive_login(self, username: str, password: str, profile_dir: str = None, **kwargs) -> None:
+    def interactive_login(self, username: str, password: str, profile_dir: str = None, **kwargs) -> Optional[Dict[str, Any]]:
         """
         Opens a visible browser so the user can manually bypass MFA/Captchas.
+
+        May optionally return a data dict in the same shape as fetch_data()'s
+        return value (balance/status/etc.), scraped directly from the
+        already-authenticated session before it closes. When a dict is returned,
+        the caller persists it immediately instead of launching a separate
+        fetch_data() call — avoiding a second browser session that may not
+        inherit the login (e.g. on sites that gate every login behind MFA/2FA
+        with no way to stay signed in). Plugins that can't scrape data from
+        within the login flow (e.g. manual mode using a native, non-automated
+        browser) should keep returning None, which falls back to a normal
+        fetch_data() call afterward.
         """
         pass
 

--- a/plugins/british.py
+++ b/plugins/british.py
@@ -415,7 +415,7 @@ class BritishAirwaysPlugin(ProviderPlugin):
     def _get_chrome_path(self) -> Optional[str]:
         return get_chrome_binary()
 
-    def interactive_login(self, username: str, password: str, profile_dir: str = None, **kwargs) -> None:
+    def interactive_login(self, username: str, password: str, profile_dir: str = None, **kwargs) -> Optional[Dict[str, Any]]:
         try:
             if profile_dir:
                 try:
@@ -477,6 +477,7 @@ class BritishAirwaysPlugin(ProviderPlugin):
                         self._save_cache(profile_dir, result)
                         self.save_cookies_to_json(sb, profile_dir)
                     print(f"Successfully captured British Airways Avios balance: {result['balance']}")
+                    return result
                 else:
                     raise PluginError(
                         "Successfully logged in, but could not read Avios balance from the dashboard. "

--- a/plugins/jetblue.py
+++ b/plugins/jetblue.py
@@ -406,7 +406,7 @@ class JetBluePlugin(ProviderPlugin):
     def _get_chrome_path(self) -> Optional[str]:
         return get_chrome_binary()
 
-    def interactive_login(self, username: str, password: str, profile_dir: str = None, **kwargs) -> None:
+    def interactive_login(self, username: str, password: str, profile_dir: str = None, **kwargs) -> Optional[Dict[str, Any]]:
         try:
             if profile_dir:
                 try:
@@ -464,6 +464,7 @@ class JetBluePlugin(ProviderPlugin):
                         self._save_cache(profile_dir, result)
                         self.save_cookies_to_json(sb, profile_dir)
                     print(f"Successfully captured JetBlue TrueBlue balance: {result['balance']}")
+                    return result
                 else:
                     raise PluginError(
                         "Successfully logged in, but could not read TrueBlue balance from the dashboard. "

--- a/plugins/wyndham.py
+++ b/plugins/wyndham.py
@@ -399,7 +399,7 @@ class WyndhamPlugin(ProviderPlugin):
         except Exception as e:
             raise PluginError(f"Scraping failed: {str(e)}")
 
-    def interactive_login(self, username: str, password: str, profile_dir: str = None, **kwargs) -> None:
+    def interactive_login(self, username: str, password: str, profile_dir: str = None, **kwargs) -> Optional[Dict[str, Any]]:
         """
         Interactive login to allow the user to resolve MFA / captchas and log in to Wyndham.
         """
@@ -454,7 +454,17 @@ class WyndhamPlugin(ProviderPlugin):
             if balance is None:
                 raise PluginError("Failed to extract account details after interactive login. Please check if you signed in successfully.")
 
-
+            result = {
+                "balance": balance,
+                "status": status or "Unknown",
+                "expiration_date": None,
+                "certificates": [],
+                # Set to None so app.py doesn't overwrite computed_expiration, matching fetch_data().
+                "last_activity_date": None
+            }
+            expiration_date = self._extract_expiration(sb, balance)
+            if expiration_date:
+                result["expiration_date"] = expiration_date.strftime("%Y-%m-%dT%H:%M:%S")
 
             if profile_dir:
                 try:
@@ -462,3 +472,4 @@ class WyndhamPlugin(ProviderPlugin):
                 except Exception:
                     pass
             print(f"Interactive login succeeded. Balance: {balance}, Status: {status}")
+            return result

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -244,8 +244,6 @@
                   <div class="flex items-center gap-1" id="sync-status-{{ account.id }}">
                       {% if account.is_manual %}
                           <span class="text-indigo-500 font-medium">Updated {{ time_ago(account.last_updated) }}</span>
-                      {% elif account.last_fetch_status == 'SUCCESS' and account.last_error and 'interactive login succeeded' in account.last_error.lower() %}
-                          <span class="text-amber-600 font-medium" title="{{ account.last_error }}">Interactive sign-in passed, but sync is pending</span>
                       {% elif account.last_fetch_status == 'SUCCESS' %}
                           <span class="text-emerald-600 font-medium">Synced ({{ time_ago(account.last_updated) }})</span>
                       {% elif account.last_fetch_status == 'FAILED' %}

--- a/tests/test_apis_and_plugins.py
+++ b/tests/test_apis_and_plugins.py
@@ -1979,28 +1979,100 @@ class TestAPIsAndPlugins(unittest.TestCase):
             # Verify safe_call was only called for the normal account (once)
             self.assertEqual(mock_safe_call.call_count, 1)
 
-    def test_dashboard_renders_interactive_login_passed_sync_pending(self):
-        # Create an account in the interactive-login-succeeded-but-sync-pending state
+    def test_interactive_login_persists_data_in_same_run(self):
+        """
+        When a manual-mode plugin's interactive_login() returns scraped data directly,
+        the /accounts/<id>/interactive route must persist it immediately and must NOT
+        fall back to a second fetch_data() call/browser launch.
+        """
+        from unittest.mock import patch
+
+        provider_british = Provider(name="British Airways Executive Club", plugin_name="british", enabled=True)
+        db.session.add(provider_british)
+        db.session.commit()
+
         account = Account(
-            provider_id=self.provider_auto.id,
+            provider_id=provider_british.id,
             person_id=self.person.id,
-            username="pending_sync_user",
-            password_encrypted=security_manager.encrypt("pass"),
+            username="ba_user",
+            password_encrypted=security_manager.encrypt("ba_pass"),
             is_manual=False,
             balance=1000,
-            status="Silver",
-            last_fetch_status="SUCCESS",
-            last_error="Interactive Login succeeded. Please click 'Sync Now' to synchronize your points."
+            status="Bronze",
+            last_fetch_status="FAILED"
         )
         db.session.add(account)
         db.session.commit()
-        
-        # Request the index page
-        res = self.client.get('/')
-        self.assertEqual(res.status_code, 200)
-        
-        # Verify it renders the specific status text
-        self.assertIn(b"Interactive sign-in passed, but sync is pending", res.data)
+
+        def fake_safe_call(func, *args, **kwargs):
+            if func.__name__ == 'interactive_login':
+                return {
+                    'balance': 5000,
+                    'status': 'Gold',
+                    'last_activity_date': datetime(2026, 1, 1)
+                }
+            raise AssertionError(
+                f"fetch_data() must not be called when interactive_login() already "
+                f"returned data in the same run (got call to {func.__name__})"
+            )
+
+        with patch('app.safe_call_plugin_method', side_effect=fake_safe_call) as mock_safe_call:
+            response = self.client.post(f'/accounts/{account.id}/interactive', follow_redirects=False)
+            self.assertEqual(response.status_code, 302)
+
+            # Only the interactive_login call should have happened -- no separate fetch_data call
+            self.assertEqual(mock_safe_call.call_count, 1)
+
+        db.session.refresh(account)
+        self.assertEqual(account.balance, 5000)
+        self.assertEqual(account.status, "Gold")
+        self.assertEqual(account.last_fetch_status, "SUCCESS")
+
+    def test_interactive_login_failure_does_not_attempt_fetch_data(self):
+        """
+        When interactive_login() itself fails (e.g. MFA not completed), the route must
+        flash the failure and leave the account entirely untouched -- it must NOT attempt
+        a fetch_data() fallback, since no authenticated session exists to scrape from.
+        """
+        from unittest.mock import patch
+
+        provider_british = Provider(name="British Airways Executive Club", plugin_name="british", enabled=True)
+        db.session.add(provider_british)
+        db.session.commit()
+
+        account = Account(
+            provider_id=provider_british.id,
+            person_id=self.person.id,
+            username="ba_user",
+            password_encrypted=security_manager.encrypt("ba_pass"),
+            is_manual=False,
+            balance=1000,
+            status="Bronze",
+            last_fetch_status="SUCCESS"
+        )
+        db.session.add(account)
+        db.session.commit()
+
+        def fake_safe_call(func, *args, **kwargs):
+            if func.__name__ == 'interactive_login':
+                raise Exception("Interactive login timed out after 5 minutes.")
+            raise AssertionError(
+                f"fetch_data() must not be attempted after interactive_login() failed "
+                f"(got call to {func.__name__})"
+            )
+
+        with patch('app.safe_call_plugin_method', side_effect=fake_safe_call) as mock_safe_call:
+            response = self.client.post(f'/accounts/{account.id}/interactive', follow_redirects=False)
+            self.assertEqual(response.status_code, 302)
+
+            # Only the failed interactive_login call should have happened
+            self.assertEqual(mock_safe_call.call_count, 1)
+
+        # Account must be completely untouched -- no partial/empty data written
+        db.session.refresh(account)
+        self.assertEqual(account.balance, 1000)
+        self.assertEqual(account.status, "Bronze")
+        self.assertEqual(account.last_fetch_status, "SUCCESS")
 
     def test_dashboard_renders_generic_sync_failure_both_options(self):
         # Create an account with a generic/vague failure


### PR DESCRIPTION
## Summary
- Interactive Login only established a session; the app then required a separate "Sync Now" click that launched a second browser and re-authenticated — which can fail on sites that gate every login behind MFA, since no human is present for that second attempt.
- For manual-mode plugins (British Airways, JetBlue, Wyndham), which launch a native, non-automated Chrome window for login and already run a follow-up headless session to scrape the balance, that scraped result was being discarded instead of returned.
- The plugin interface now optionally returns the scraped data from `interactive_login()`, and the interactive-login route uses it directly when present — no second browser launch, and no more separate "Sync Now" step required after a successful login. Plugins that can't scrape mid-login still fall back to the previous two-step behavior.

## Test plan
- [x] Full test suite passes (166 passed, 3 skipped) except one pre-existing, unrelated failure (`TestMarriottExpirationParsing::test_explicit_english_iso_expiration`, confirmed present on `main` before this branch — a date-relative test issue unaffected by this change)
- [x] All 31 plugins load cleanly via the plugin manager
- [x] Manually verified end-to-end against a live account