### PR TITLE
fix(interactive-login): capture data immediately for assisted-mode plugins

### DIFF
--- a/app.py
+++ b/app.py
@@ -1257,6 +1257,10 @@ def create_app(config_class=Config):
             send_desktop_notification("Sync Successful", f"{account.display_name} balance updated successfully to {account.balance:,} points.")
             flash(f'{account.display_name} logged in and synced successfully.')
         except Exception as e:
+            # Discard any partial mutations _persist_fetch_result staged before raising
+            # (e.g. balance/status already set, old certificates marked for deletion)
+            # so only the FAILED status below gets committed, not a half-applied sync.
+            db.session.rollback()
             account.last_fetch_status = 'FAILED'
             account.last_error = str(e)
             account.last_updated = datetime.utcnow()

--- a/plugins/aircanada.py
+++ b/plugins/aircanada.py
@@ -709,7 +709,7 @@ class AirCanadaPlugin(ProviderPlugin):
             except Exception as e:
                 raise PluginError(f"Air Canada scraping failed: {e}")
 
-    def interactive_login(self, username: str, password: str, profile_dir: str = None, **kwargs) -> None:
+    def interactive_login(self, username: str, password: str, profile_dir: str = None, **kwargs) -> Optional[Dict[str, Any]]:
         with SB(**get_sb_kwargs(uc=True, user_data_dir=profile_dir)) as sb:
             print("Opening Air Canada home page for interactive login...")
             sb.open("https://www.aircanada.com/ca/en/aco/home.html")
@@ -773,26 +773,47 @@ class AirCanadaPlugin(ProviderPlugin):
                         sb.sleep(8)
                         
                         html = sb.get_page_source()
-                        balance, _, _ = self._extract_data(html)
-                        
+                        balance, status, expiration_date = self._extract_data(html)
+
                         # Fallback to my-aeroplan.html if first extraction gets None
                         if balance is None:
                             print("Navigating to My Aeroplan dashboard directly as fallback...")
                             sb.open("https://www.aircanada.com/ca/en/aco/home/aeroplan/my-aeroplan.html")
                             sb.sleep(8)
                             html = sb.get_page_source()
-                            balance, _, _ = self._extract_data(html)
-                            
+                            balance, status, expiration_date = self._extract_data(html)
+
                         if balance is not None:
                             success = True
                             print(f"Interactive login successful! Found balance: {balance}.")
                             break
-                        
+
                     time.sleep(4)
-                    
+
                 if not success:
                     raise PluginError("Interactive login timed out or failed to reach Aeroplan dashboard.")
                 sb.sleep(3)
+
+                # Fetch last activity date from detailed transaction activity page, matching
+                # fetch_data()'s extraction so expiration is computed the same way.
+                last_activity_date = None
+                try:
+                    print("Navigating to detailed Aeroplan Member Activity page to fetch transaction history...")
+                    sb.open("https://www.aircanada.com/aeroplan/member/dashboard/activity")
+                    sb.sleep(8)
+                    if not self._is_error_page(sb):
+                        activity_html = sb.get_page_source()
+                        last_activity_date = self._extract_last_activity_date(activity_html)
+                        print(f"Scraped Aeroplan last activity date: {last_activity_date}")
+                except Exception as e:
+                    print(f"Warning: Could not fetch last activity history: {e}")
+
+                return {
+                    "balance": balance,
+                    "status": status,
+                    "last_activity_date": last_activity_date,
+                    "expiration_date": expiration_date
+                }
             except WebDriverException as e:
                 if "invalid session id" in str(e).lower():
                     raise PluginError("Air Canada browser session was lost or closed. Please keep the browser open until the dashboard is fully loaded.")

--- a/plugins/american.py
+++ b/plugins/american.py
@@ -334,7 +334,7 @@ class AmericanAirlinesPlugin(ProviderPlugin):
         except Exception as e:
             raise PluginError(f"Scraping failed: {str(e)}")
 
-    def interactive_login(self, username: str, password: str, profile_dir: str = None) -> None:
+    def interactive_login(self, username: str, password: str, profile_dir: str = None) -> Optional[Dict[str, Any]]:
         """
         Interactive login to allow the user to resolve captchas and log in to American Airlines.
         """
@@ -369,15 +369,21 @@ class AmericanAirlinesPlugin(ProviderPlugin):
                         sb.sleep(5)
                         if self._check_for_mfa(sb) or sb.is_element_present("adc-text-input#username"):
                             continue
-                        balance, _, _, _ = self._extract_data(sb)
+                        balance, status, exp_date, last_act = self._extract_data(sb)
                         if balance is not None:
                             success = True
                             break
                     time.sleep(2)
-                
+
                 if not success:
                     raise PluginError("Interactive login timed out after 5 minutes or dashboard failed to load.")
-                
+
                 sb.sleep(3) # Let session write completely
+                return {
+                    "balance": balance,
+                    "status": status or "Member",
+                    "expiration_date": exp_date,
+                    "last_activity_date": last_act
+                }
             except Exception:
                 raise PluginError("Interactive login timed out after 5 minutes or dashboard failed to load.")

--- a/plugins/ana.py
+++ b/plugins/ana.py
@@ -673,7 +673,8 @@ class ANAPlugin(ProviderPlugin):
                     return cached
             raise PluginError(f"ANA scraping failed: {e}")
 
-    def interactive_login(self, username: str, password: str, profile_dir: str = None, **kwargs) -> None:
+    def interactive_login(self, username: str, password: str, profile_dir: str = None, **kwargs) -> Optional[Dict[str, Any]]:
+        result = None
         try:
             with SB(**get_sb_kwargs(uc=True, user_data_dir=profile_dir, headed=True)) as sb:
                 sb.open("https://www.ana.co.jp/en/jp/amc/")
@@ -718,6 +719,7 @@ class ANAPlugin(ProviderPlugin):
                     sb.sleep(5)
                 if not logged_in:
                     raise PluginError("Interactive login timed out or failed.")
+                return result
         except Exception as e:
             self._raise_if_window_closed(e)
             raise PluginError(f"Interactive login error: {e}")

--- a/plugins/asiana.py
+++ b/plugins/asiana.py
@@ -447,7 +447,7 @@ class AsianaAirlinesPlugin(ProviderPlugin):
                     return cached
             raise PluginError(f"Asiana Airlines scraping failed: {e}")
 
-    def interactive_login(self, username: str, password: str, profile_dir: str = None) -> None:
+    def interactive_login(self, username: str, password: str, profile_dir: str = None) -> Optional[Dict[str, Any]]:
         with SB(**get_sb_kwargs(uc=True, user_data_dir=profile_dir, headed=True)) as sb:
             sb.open("https://flyasiana.com/")
             sb.sleep(6)
@@ -486,7 +486,7 @@ class AsianaAirlinesPlugin(ProviderPlugin):
                                 if profile_dir:
                                     self._save_cache(profile_dir, result)
                                 print(f"Successfully captured Asiana mileage: {result['balance']}")
-                                break
+                                return result
                     sb.sleep(5)
             except Exception as e:
                 print(f"Interactive login wait interrupted: {e}")

--- a/plugins/avianca.py
+++ b/plugins/avianca.py
@@ -77,8 +77,12 @@ class AviancaLifemilesPlugin(ProviderPlugin):
                         num_str = m.group(1).replace(",", "").replace(".", "")
                         if num_str.isdigit():
                             val = int(num_str)
-                            # Make sure we don't accidentally parse small menu counts or dates
-                            if val > 100 or any(kw in text.lower() for kw in ["mile", "lm", "puntos"]):
+                            # Make sure we don't accidentally parse small menu counts or dates.
+                            # A bare 0 is allowed through unconditionally: it's a legitimate
+                            # balance value (e.g. a new/depleted account) and, unlike other
+                            # small numbers, isn't plausibly confused with a menu badge or date
+                            # fragment, so it doesn't need the keyword-adjacency check below.
+                            if val == 0 or val > 100 or any(kw in text.lower() for kw in ["mile", "lm", "puntos"]):
                                 balance = val
                                 break
             except Exception:
@@ -259,25 +263,46 @@ class AviancaLifemilesPlugin(ProviderPlugin):
         """
         import datetime as dt
         latest_accrual = None
+        rows = []
         has_redemptions = False
         has_accruals = False
         
         # List of potential transaction history URLs
         urls = [
+            "https://www.lifemiles.com/account/activity",
             "https://www.lifemiles.com/profile/transactions",
             "https://www.lifemiles.com/member/transactions",
             "https://www.lifemiles.com/profile/activity",
             "https://www.lifemiles.com/transactions"
         ]
-        
+
         # Try navigating directly
         navigated = False
         for url in urls:
             try:
                 sb.open(url)
                 sb.sleep(6)
-                # Check if we landed on a page with transactions
-                if "transaction" in sb.get_current_url().lower() or "actividad" in sb.get_current_url().lower() or "activity" in sb.get_current_url().lower():
+                # Check if we landed on a real page (matching URL alone isn't enough —
+                # a dead guessed URL like /profile/transactions still contains
+                # "transaction" even on its own 404/"does not exist" error page).
+                curr_url = sb.get_current_url().lower()
+                # Only scan rendered, visible text (not the raw page source) for error
+                # phrases — this is a React SPA, and the raw HTML includes the full JS
+                # bundle, which ships generic error-boundary/404-handling code as text
+                # on every page regardless of whether an error actually occurred.
+                # Normalize curly/smart apostrophes (e.g. "can't") to straight ones so the
+                # keyword match below isn't broken by the site's typography.
+                error_check_soup = BeautifulSoup(sb.get_page_source(), "html.parser")
+                for tag in error_check_soup(["script", "style"]):
+                    tag.decompose()
+                page_text = error_check_soup.get_text(" ").lower().replace("’", "'").replace("‘", "'")
+                looks_like_error = any(kw in page_text for kw in [
+                    "page not found", "can't be found", "cannot be found",
+                    "does not exist", "no existe", "404", "no encontrada", "página no encontrada"
+                ])
+                if not looks_like_error and (
+                    "transaction" in curr_url or "actividad" in curr_url or "activity" in curr_url
+                ):
                     navigated = True
                     break
             except Exception:
@@ -324,7 +349,7 @@ class AviancaLifemilesPlugin(ProviderPlugin):
                     rows.append(line)
                     
             rows = list(set(rows))
-            
+
             months = {
                 "jan": 1, "feb": 2, "mar": 3, "apr": 4, "may": 5, "jun": 6,
                 "jul": 7, "aug": 8, "sep": 9, "oct": 10, "nov": 11, "dec": 12,
@@ -381,7 +406,7 @@ class AviancaLifemilesPlugin(ProviderPlugin):
                     
         except Exception as e:
             print("Error parsing transactions page:", e)
-            
+
         no_accruals_warning = (has_redemptions and not has_accruals) or (has_redemptions and not latest_accrual)
         return latest_accrual, no_accruals_warning
 
@@ -693,7 +718,7 @@ class AviancaLifemilesPlugin(ProviderPlugin):
         except Exception as e:
             raise PluginError(f"Avianca LifeMiles scraping failed: {str(e)}")
 
-    def interactive_login(self, username: str, password: str, profile_dir: str = None) -> None:
+    def interactive_login(self, username: str, password: str, profile_dir: str = None) -> Optional[Dict[str, Any]]:
         """
         Launches a headed browser window, helps pre-fill credentials when the Keycloak
         form is reached, and automatically closes the browser once active session data is parsed.
@@ -743,7 +768,7 @@ class AviancaLifemilesPlugin(ProviderPlugin):
                     # Verify if redirected back to lifemiles and points balance is loaded
                     if "lifemiles.com" in parsed.netloc:
                         html = sb.get_page_source()
-                        balance, _ = self._extract_data(html)
+                        balance, status = self._extract_data(html)
                         if balance is not None:
                             success = True
                             print(f"Interactive login successful! Found balance: {balance}. Auto-closing browser in 5 seconds...")
@@ -752,6 +777,33 @@ class AviancaLifemilesPlugin(ProviderPlugin):
                 except Exception:
                     pass
                 time.sleep(4)
-                
+
             if not success:
+                try:
+                    with open("avianca_interactive_timeout_dump.html", "w", encoding="utf-8") as f:
+                        f.write(sb.get_page_source())
+                    print(f"Saved timeout debug dump. Final URL: {sb.get_current_url()}")
+                except Exception:
+                    pass
                 raise PluginError("Interactive login timed out or failed to reach dashboard.")
+
+            result = {
+                "balance": balance,
+                "status": status or "Clásico",
+                "expiration_date": None,
+                "certificates": []
+            }
+            # The overview page directly displays an explicit "Expiration date" field
+            # (e.g. "Dec 31, 2026"), so unlike last_activity_date-based expiration
+            # calculations, this doesn't need the fragile transactions-page URL hunt
+            # in _fetch_last_accrual_date() — it's parsed straight from the page
+            # already captured above.
+            try:
+                exp_date = self._extract_expiration_date(html)
+                if exp_date:
+                    from datetime import datetime
+                    result["expiration_date"] = datetime.strptime(exp_date, "%Y-%m-%d")
+            except Exception as de:
+                print("Error parsing expiration date:", de)
+
+            return result

--- a/plugins/caesars.py
+++ b/plugins/caesars.py
@@ -329,7 +329,7 @@ class CaesarsRewardsPlugin(ProviderPlugin):
         except Exception as e:
             raise PluginError(f"Scraping failed: {str(e)}")
 
-    def interactive_login(self, username: str, password: str, profile_dir: str = None) -> None:
+    def interactive_login(self, username: str, password: str, profile_dir: str = None) -> Optional[Dict[str, Any]]:
         """
         Interactive login to allow the user to resolve MFA / captchas and log in to Caesars Rewards.
         """
@@ -361,15 +361,22 @@ class CaesarsRewardsPlugin(ProviderPlugin):
                         # Auto-skip MFA enrollment promo during interactive login if it shows up
                         self._handle_mfa_enrollment_promo(sb)
                         
-                        balance, _, _ = self._extract_data(sb)
+                        balance, status, last_activity = self._extract_data(sb)
                         if balance is not None:
                             success = True
                             break
                     time.sleep(2)
-                    
+
                 if not success:
                     raise PluginError("Interactive login timed out after 5 minutes or profile page failed to load.")
-                    
+
                 sb.sleep(5) # Let session save
+                return {
+                    "balance": balance,
+                    "status": status or "Unknown",
+                    "expiration_date": None,
+                    "certificates": [],
+                    "last_activity_date": last_activity
+                }
             except Exception:
                 raise PluginError("Interactive login timed out after 5 minutes or profile page failed to load.")

--- a/plugins/enterprise.py
+++ b/plugins/enterprise.py
@@ -303,7 +303,7 @@ class EnterprisePlugin(ProviderPlugin):
         except Exception as e:
             raise PluginError(f"Scraping failed: {str(e)}")
 
-    def interactive_login(self, username: str, password: str, profile_dir: str = None) -> None:
+    def interactive_login(self, username: str, password: str, profile_dir: str = None) -> Optional[Dict[str, Any]]:
         """
         Interactive login to allow the user to resolve MFA / captchas and log in to Enterprise.
         """
@@ -329,27 +329,35 @@ class EnterprisePlugin(ProviderPlugin):
             try:
                 start_time = time.time()
                 success = False
+                status, last_activity = None, None
                 while time.time() - start_time < 300:
-                    balance, _, _ = self._extract_data(sb)
+                    balance, status, last_activity = self._extract_data(sb)
                     if balance is not None:
                         success = True
                         break
-                    
+
                     if sb.is_element_visible("a#tab_reward"):
                         try:
                             sb.click("a#tab_reward")
                             sb.sleep(3)
-                            balance, _, _ = self._extract_data(sb)
+                            balance, status, last_activity = self._extract_data(sb)
                             if balance is not None:
                                 success = True
                                 break
                         except Exception:
                             pass
                     time.sleep(2)
-                    
+
                 if not success:
                     raise PluginError("Interactive login timed out after 5 minutes or dashboard failed to load.")
-                    
+
                 sb.sleep(5)
+                return {
+                    "balance": balance,
+                    "status": status or "Unknown",
+                    "expiration_date": None,
+                    "certificates": [],
+                    "last_activity_date": last_activity
+                }
             except Exception:
                 raise PluginError("Interactive login timed out after 5 minutes or dashboard failed to load.")

--- a/plugins/eva.py
+++ b/plugins/eva.py
@@ -470,7 +470,8 @@ class EVAPlugin(ProviderPlugin):
                     return cached
             raise PluginError(f"EVA Air scraping failed: {e}")
 
-    def interactive_login(self, username: str, password: str, profile_dir: str = None, **kwargs) -> None:
+    def interactive_login(self, username: str, password: str, profile_dir: str = None, **kwargs) -> Optional[Dict[str, Any]]:
+        result = None
         try:
             with SB(**get_sb_kwargs(uc=True, user_data_dir=profile_dir, headed=True)) as sb:
                 print("Opening EVA Air login page with redirect target...")
@@ -525,6 +526,7 @@ class EVAPlugin(ProviderPlugin):
                 
                 if not logged_in:
                     raise PluginError("Interactive login timed out or failed.")
+                return result
         except Exception as e:
             self._raise_if_window_closed(e)
             raise PluginError(f"Interactive login error: {e}")

--- a/plugins/hertz.py
+++ b/plugins/hertz.py
@@ -250,7 +250,7 @@ class HertzPlugin(ProviderPlugin):
         except Exception as e:
             raise PluginError(f"Scraping failed: {str(e)}")
 
-    def interactive_login(self, username: str, password: str, profile_dir: str = None) -> None:
+    def interactive_login(self, username: str, password: str, profile_dir: str = None) -> Optional[Dict[str, Any]]:
         """
         Interactive login to allow the user to resolve MFA / captchas and log in to Hertz.
         """
@@ -279,15 +279,22 @@ class HertzPlugin(ProviderPlugin):
                     curr_url = sb.get_current_url()
                     # Check if logged in
                     if "profile.do" in curr_url or "emember" in curr_url:
-                        balance, _, _ = self._extract_data(sb)
+                        balance, status, last_activity = self._extract_data(sb)
                         if balance is not None:
                             success = True
                             break
                     time.sleep(2)
-                    
+
                 if not success:
                     raise PluginError("Interactive login timed out after 5 minutes or profile page failed to load.")
-                    
+
                 sb.sleep(5)
+                return {
+                    "balance": balance,
+                    "status": status or "Unknown",
+                    "expiration_date": None,
+                    "certificates": [],
+                    "last_activity_date": last_activity
+                }
             except Exception:
                 raise PluginError("Interactive login timed out after 5 minutes or profile page failed to load.")

--- a/plugins/hilton.py
+++ b/plugins/hilton.py
@@ -391,7 +391,7 @@ class HiltonHonorsPlugin(ProviderPlugin):
         except Exception as e:
             raise PluginError(f"Scraping failed: {str(e)}")
 
-    def interactive_login(self, username: str, password: str, profile_dir: str = None) -> None:
+    def interactive_login(self, username: str, password: str, profile_dir: str = None) -> Optional[Dict[str, Any]]:
         """
         Opens an interactive browser window for the user to resolve MFA.
         Uses the same user_data_dir so cookies are saved for future headless runs.
@@ -411,16 +411,42 @@ class HiltonHonorsPlugin(ProviderPlugin):
                 start_time = time.time()
                 success = False
                 while time.time() - start_time < 300:
-                    balance, _, _ = self._extract_data(sb)
+                    balance, status, last_activity = self._extract_data(sb)
                     if balance is not None:
                         success = True
                         break
                     time.sleep(2)
-                
+
                 if not success:
                     raise PluginError("Interactive login timed out after 5 minutes or points were not found.")
-                
+
                 # Let it settle so cookies save
                 sb.sleep(5)
+
+                # Navigate to the dedicated activity page for the last activity date, matching
+                # fetch_data() — the login-redirect page found above may lack transaction history,
+                # so last_activity here can't be trusted the way fetch_data()'s can.
+                try:
+                    sb.open("https://www.hilton.com/en/hilton-honors/guest/activity/")
+                    sb.sleep(8)
+                    activity_balance, activity_status, activity_last_activity = self._extract_data(sb)
+                    if activity_balance is not None:
+                        balance = activity_balance
+                    if activity_status:
+                        status = activity_status
+                    if activity_last_activity:
+                        last_activity = activity_last_activity
+                except Exception as e:
+                    print(f"Warning: Could not fetch Hilton activity page for last activity date: {e}")
+
+                result = {
+                    "balance": balance,
+                    "status": status or "Unknown",
+                    "expiration_date": None,
+                    "certificates": []
+                }
+                if last_activity:
+                    result["last_activity_date"] = last_activity
+                return result
             except Exception:
                 raise PluginError("Interactive login timed out after 5 minutes or activity page failed to load.")

--- a/plugins/ihg.py
+++ b/plugins/ihg.py
@@ -296,7 +296,7 @@ class IHGRewardsPlugin(ProviderPlugin):
         except Exception as e:
             raise PluginError(f"Scraping failed: {str(e)}")
 
-    def interactive_login(self, username: str, password: str, profile_dir: str = None) -> None:
+    def interactive_login(self, username: str, password: str, profile_dir: str = None) -> Optional[Dict[str, Any]]:
         """
         Opens an interactive browser window for the user to resolve MFA.
         Uses the same user_data_dir so cookies are saved for future headless runs.
@@ -343,15 +343,22 @@ class IHGRewardsPlugin(ProviderPlugin):
                 sb.sleep(8)
 
             # Confirm we can read the balance (validates the session is live)
-            balance, _ = self._extract_data(sb)
+            balance, status = self._extract_data(sb)
             if balance is None:
                 sb.refresh()
                 sb.sleep(8)
-                balance, _ = self._extract_data(sb)
+                balance, status = self._extract_data(sb)
 
             # Let cookies flush to disk before closing
             sb.sleep(3)
 
             if balance is None:
                 raise PluginError("Interactive login completed but could not read points balance on account overview.")
+
+            return {
+                "balance": balance,
+                "status": status or "Unknown",
+                "expiration_date": None,
+                "certificates": []
+            }
 

--- a/plugins/korean.py
+++ b/plugins/korean.py
@@ -768,9 +768,10 @@ class KoreanAirPlugin(ProviderPlugin):
                     return cached
             raise PluginError(f"Korean Air scraping failed: {e}")
 
-    def interactive_login(self, username: str, password: str, profile_dir: str = None) -> None:
+    def interactive_login(self, username: str, password: str, profile_dir: str = None) -> Optional[Dict[str, Any]]:
         if username:
             username = username.replace(' ', '')
+        result = None
         with SB(**get_sb_kwargs(uc=True, user_data_dir=profile_dir, headed=True)) as sb:
             sb.open("https://www.koreanair.com/login")
             sb.sleep(3)
@@ -844,3 +845,4 @@ class KoreanAirPlugin(ProviderPlugin):
                     sb.sleep(5)
             except Exception as e:
                 print(f"Interactive login wait interrupted: {e}")
+        return result

--- a/plugins/marriott.py
+++ b/plugins/marriott.py
@@ -346,20 +346,20 @@ class MarriottPlugin(ProviderPlugin):
         except Exception as e:
             raise PluginError(f"Scraping failed: {str(e)}")
 
-    def interactive_login(self, username: str, password: str, profile_dir: str = None) -> None:
+    def interactive_login(self, username: str, password: str, profile_dir: str = None) -> Optional[Dict[str, Any]]:
         """
         Interactive login to allow the user to resolve MFA / captchas and log in to Marriott Bonvoy.
         """
         with SB(uc=True, headless=False, user_data_dir=profile_dir) as sb:
             sb.uc_open_with_reconnect("https://www.marriott.com/sign-in.mi", 4)
             sb.sleep(4)
-            
+
             # Prefill credentials if form is visible
             try:
                 self._fill_login_form(sb, username, password, auto_submit=False)
             except Exception:
                 pass
-            
+
             # Monitor URL and close window automatically when logged in
             try:
                 start_time = time.time()
@@ -376,10 +376,56 @@ class MarriottPlugin(ProviderPlugin):
                             success = True
                             break
                     time.sleep(2)
-                
+
                 if not success:
                     raise PluginError("Interactive login timed out after 5 minutes or dashboard failed to load.")
-                
+
                 sb.sleep(3) # Let session write completely
+
+                # Extract balance/status/expiration now that the session is live, mirroring
+                # fetch_data()'s post-login extraction so no second browser launch is needed.
+                import urllib.parse
+                current_url = sb.get_current_url()
+                lang_prefix = ""
+                try:
+                    parsed_url = urllib.parse.urlparse(current_url)
+                    path_parts = parsed_url.path.strip("/").split("/")
+                    if path_parts and len(path_parts[0]) == 2:
+                        lang_prefix = f"/{path_parts[0]}"
+                except Exception:
+                    pass
+
+                activity_url = f"https://www.marriott.com{lang_prefix}/loyalty/myAccount/activity.mi"
+                sb.open(activity_url)
+                sb.sleep(6)
+
+                balance, status = self._extract_from_datalayer(sb.get_page_source())
+                if balance is None:
+                    points_selector = ".m-account-points, [data-testid='member-points'], [data-testid*='points-balance'], .points-value, .t-subtitle-xl"
+                    try:
+                        sb.wait_for_element_visible(points_selector, timeout=10)
+                        clean_points = "".join(filter(str.isdigit, sb.get_text(points_selector)))
+                        if clean_points:
+                            balance = int(clean_points)
+                    except Exception:
+                        pass
+                    try:
+                        status_text = sb.get_text(".m-account-status, [data-testid='member-status'], .t-label-s")
+                        status = status_text.strip()
+                    except Exception:
+                        pass
+
+                if balance is None:
+                    with open("marriott_activity_dump.html", "w", encoding="utf-8") as f:
+                        f.write(sb.get_page_source())
+                    raise PluginError("Logged in successfully, but could not find points on activity page. Page source saved to marriott_activity_dump.html.")
+
+                result = {"balance": balance, "status": "Unknown", "expiration_date": None, "certificates": []}
+                expiration_date = self._extract_expiration_date(sb.get_page_source())
+                if expiration_date is not None:
+                    result["expiration_date"] = expiration_date
+                if status:
+                    result["status"] = status
+                return result
             except Exception as e:
                 raise PluginError(f"Interactive login timed out or failed: {e}")

--- a/plugins/national.py
+++ b/plugins/national.py
@@ -306,7 +306,7 @@ class NationalPlugin(ProviderPlugin):
         except Exception as e:
             raise PluginError(f"Scraping failed: {str(e)}")
 
-    def interactive_login(self, username: str, password: str, profile_dir: str = None, **kwargs) -> None:
+    def interactive_login(self, username: str, password: str, profile_dir: str = None, **kwargs) -> Optional[Dict[str, Any]]:
         """
         Interactive login to allow the user to resolve MFA / captchas and log in to National.
         """
@@ -340,20 +340,27 @@ class NationalPlugin(ProviderPlugin):
                 start_time = time.time()
                 success = False
                 while time.time() - start_time < 300:
-                    balance, _, _ = self._extract_data(sb)
+                    balance, status, last_activity = self._extract_data(sb)
                     if balance is not None:
                         success = True
                         break
                     time.sleep(2)
-                    
+
                 if not success:
                     raise PluginError("Interactive login timed out after 5 minutes or dashboard failed to load.")
-                
+
                 if profile_dir:
                     try:
                         self.save_cookies_to_json(sb, profile_dir)
                     except Exception:
                         pass
                 sb.sleep(5)
+                return {
+                    "balance": balance,
+                    "status": status or "Unknown",
+                    "expiration_date": None,
+                    "certificates": [],
+                    "last_activity_date": last_activity
+                }
             except Exception as e:
                 raise PluginError(f"Interactive login timed out or failed: {e}")

--- a/plugins/southwest.py
+++ b/plugins/southwest.py
@@ -280,7 +280,7 @@ class SouthwestPlugin(ProviderPlugin):
             except Exception as e:
                 raise PluginError(f"Southwest scraping failed: {e}")
 
-    def interactive_login(self, username: str, password: str, profile_dir: str = None) -> None:
+    def interactive_login(self, username: str, password: str, profile_dir: str = None) -> Optional[Dict[str, Any]]:
         with SB(**get_sb_kwargs(uc=True, user_data_dir=profile_dir)) as sb:
             sb.open("https://www.southwest.com/loyalty/myaccount/")
             sb.sleep(6)
@@ -316,16 +316,21 @@ class SouthwestPlugin(ProviderPlugin):
                     if "my-account" in current_url.lower() or "loyalty/myaccount" in current_url.lower():
                         # Settle and verify points can be extracted
                         sb.sleep(5)
-                        balance, _ = self._extract_data_from_page(sb)
+                        balance, status = self._extract_data_from_page(sb)
                         if balance is not None:
                             success = True
                             print(f"Interactive login successful! Found balance: {balance}.")
                             break
                     time.sleep(3)
-                    
+
                 if not success:
                     raise PluginError("Interactive login timed out or failed to reach dashboard.")
-                    
+
                 sb.sleep(3) # Let session write completely
+                return {
+                    "balance": balance,
+                    "status": status,
+                    "expiration_date": None  # Southwest points do not expire
+                }
             except Exception as e:
                 raise PluginError(f"Interactive login timed out or failed: {e}")

--- a/plugins/united.py
+++ b/plugins/united.py
@@ -368,7 +368,7 @@ class UnitedAirlinesPlugin(ProviderPlugin):
         except Exception as e:
             raise PluginError(f"Scraping failed: {str(e)}")
 
-    def interactive_login(self, username: str, password: str, profile_dir: str = None) -> None:
+    def interactive_login(self, username: str, password: str, profile_dir: str = None) -> Optional[Dict[str, Any]]:
         """
         Interactive login to allow the user to resolve captchas and log in to United.
         """
@@ -405,16 +405,34 @@ class UnitedAirlinesPlugin(ProviderPlugin):
                     if "myunited" in curr_url and not sb.is_element_visible("input#password"):
                         # Settle and verify points can be extracted
                         sb.sleep(5)
-                        balance, _ = self._extract_data(sb)
+                        balance, status = self._extract_data(sb)
                         if balance is not None:
                             success = True
                             break
                     time.sleep(2)
-                
+
                 if not success:
                     raise PluginError("Interactive login timed out after 5 minutes or dashboard failed to load.")
-                
+
                 sb.sleep(3) # Let session write completely
+
+                result = {
+                    "balance": balance,
+                    "status": status or "Member",
+                    "expiration_date": None,  # United MileagePlus miles never expire
+                    "certificates": []
+                }
+                try:
+                    print("Navigating to United Club passes page...")
+                    sb.open("https://www.united.com/en/us/mileageplus/unitedclubpass")
+                    sb.sleep(6)
+                    html_passes = sb.get_page_source()
+                    certs = self._parse_club_passes(html_passes)
+                    if certs:
+                        result["certificates"] = certs
+                except Exception as e:
+                    print(f"Failed to fetch or parse United Club passes: {e}")
+                return result
             except Exception:
                 raise PluginError("Interactive login timed out after 5 minutes or dashboard failed to load.")
 

--- a/plugins/virgin.py
+++ b/plugins/virgin.py
@@ -5,6 +5,8 @@ from selenium.common.exceptions import WebDriverException
 from bs4 import BeautifulSoup
 import time
 import re
+import os
+import json
 from urllib.parse import urlparse
 
 class VirginAtlanticPlugin(ProviderPlugin):
@@ -29,6 +31,79 @@ class VirginAtlanticPlugin(ProviderPlugin):
 
     def get_expiration_policy_description(self, status: str = None) -> str:
         return "Miles in this program never expire."
+
+    def _cookies_path(self, profile_dir: str) -> str:
+        return os.path.join(profile_dir, "virgin_cookies.json")
+
+    def save_cookies_to_json(self, sb, profile_dir: str) -> None:
+        """
+        Explicitly serializes cookies to a JSON file. Relying on `user_data_dir`
+        alone to carry a session between two separate SB(uc=True, ...) launches is
+        unreliable (undetected-chromedriver doesn't consistently reuse a profile
+        across process relaunches), so the session is persisted explicitly instead.
+        """
+        if not profile_dir:
+            return
+        try:
+            cookies = sb.get_cookies()
+            os.makedirs(profile_dir, exist_ok=True)
+            with open(self._cookies_path(profile_dir), "w", encoding="utf-8") as f:
+                json.dump(cookies, f, indent=4)
+            print(f"Virgin Atlantic cookies saved to JSON: {len(cookies)} cookies.")
+        except Exception as e:
+            print(f"Failed to save Virgin Atlantic cookies: {e}")
+
+    def load_cookies_from_json(self, sb, profile_dir: str) -> None:
+        """Restores cookies saved by save_cookies_to_json, visiting each cookie's
+        domain first since Selenium requires an active page on that domain
+        before a cookie can be added to it."""
+        if not profile_dir:
+            return
+        cookies_file = self._cookies_path(profile_dir)
+        if not os.path.exists(cookies_file):
+            print("No saved Virgin Atlantic cookies JSON file found.")
+            return
+        try:
+            with open(cookies_file, "r", encoding="utf-8") as f:
+                cookies = json.load(f)
+
+            cookies_by_domain = {}
+            for cookie in cookies:
+                domain = cookie.get('domain', '')
+                if not domain:
+                    continue
+                norm_domain = domain.lstrip('.')
+                cookies_by_domain.setdefault(norm_domain, []).append(cookie)
+
+            for norm_domain, domain_cookies in cookies_by_domain.items():
+                current_url = sb.get_current_url().lower()
+                if norm_domain not in current_url:
+                    safe_url = f"https://{norm_domain}/"
+                    try:
+                        sb.open(safe_url)
+                        sb.sleep(2)
+                    except Exception:
+                        continue
+                for cookie in domain_cookies:
+                    try:
+                        clean_cookie = {
+                            'name': cookie['name'],
+                            'value': cookie['value'],
+                            'path': cookie.get('path', '/'),
+                            'secure': cookie.get('secure', False),
+                            'httpOnly': cookie.get('httpOnly', False),
+                            'sameSite': cookie.get('sameSite', 'Lax')
+                        }
+                        if cookie.get('domain'):
+                            clean_cookie['domain'] = cookie['domain']
+                        if 'expiry' in cookie:
+                            clean_cookie['expiry'] = int(cookie['expiry'])
+                        sb.add_cookie(clean_cookie)
+                    except Exception:
+                        pass
+            print("Virgin Atlantic cookies restore process completed.")
+        except Exception as e:
+            print(f"Failed to restore Virgin Atlantic cookies: {e}")
 
     def _extract_data(self, html: str) -> Tuple[Optional[int], Optional[str]]:
         """
@@ -272,6 +347,15 @@ class VirginAtlanticPlugin(ProviderPlugin):
         
         try:
             with SB(**get_sb_kwargs(uc=True, user_data_dir=profile_dir)) as sb:
+                # Restore the session explicitly from JSON before checking it. A fresh
+                # SB(uc=True, ...) process does not reliably inherit the previous
+                # launch's session via user_data_dir alone.
+                if profile_dir:
+                    try:
+                        self.load_cookies_from_json(sb, profile_dir)
+                    except Exception:
+                        pass
+
                 # Open dashboard directly to check for existing active session
                 print("Navigating to Flying Club summary overview...")
                 sb.open("https://www.virginatlantic.com/flying-club/account/overview")
@@ -365,6 +449,13 @@ class VirginAtlanticPlugin(ProviderPlugin):
                 result["balance"] = balance
                 if status:
                     result["status"] = status
+
+                if profile_dir:
+                    try:
+                        self.save_cookies_to_json(sb, profile_dir)
+                    except Exception:
+                        pass
+
                 return result
                 
         except InteractionRequiredError:
@@ -372,11 +463,23 @@ class VirginAtlanticPlugin(ProviderPlugin):
         except Exception as e:
             raise PluginError(f"Virgin Atlantic scraping failed: {str(e)}")
 
-    def interactive_login(self, username: str, password: str, profile_dir: str = None, **kwargs) -> None:
+    def interactive_login(self, username: str, password: str, profile_dir: str = None, **kwargs) -> Optional[Dict[str, Any]]:
         """
         Launches browser in headed mode to let the user perform interactive login.
         Automatically closes when successful dashboard loaded is detected.
+
+        Since the session is already open and authenticated at that point, the
+        balance/status are scraped from it directly and returned here, instead of
+        closing the browser and requiring a second, separate fetch_data() launch
+        (which for a program like Virgin that gates every login behind MFA offers
+        no guarantee of still being logged in).
         """
+        result = {
+            "balance": 0,
+            "status": "Member",
+            "expiration_date": None,  # Virgin Points never expire
+            "certificates": []
+        }
         with SB(**get_sb_kwargs(uc=True, user_data_dir=profile_dir)) as sb:
             # Step 1: Open homepage first to establish solid WAF session state and cookies
             print("Opening Virgin Atlantic home page to initialize session...")
@@ -450,9 +553,17 @@ class VirginAtlanticPlugin(ProviderPlugin):
                     if "flying-club/account" in parsed.path:
                         sb.sleep(4)
                         html = sb.get_page_source()
-                        balance, _ = self._extract_data(html)
+                        balance, status = self._extract_data(html)
                         if balance is not None:
                             success = True
+                            result["balance"] = balance
+                            if status:
+                                result["status"] = status
+                            if profile_dir:
+                                try:
+                                    self.save_cookies_to_json(sb, profile_dir)
+                                except Exception:
+                                    pass
                             print("Interactive login successful. Closing browser...")
                             sb.sleep(5)
                             break
@@ -469,3 +580,5 @@ class VirginAtlanticPlugin(ProviderPlugin):
                 
             if not success:
                 raise PluginError("Interactive login timed out or failed to reach dashboard.")
+
+            return result

--- a/tests/test_apis_and_plugins.py
+++ b/tests/test_apis_and_plugins.py
@@ -2323,6 +2323,285 @@ class TestAPIsAndPlugins(unittest.TestCase):
         self.assertEqual(account.status, "Bronze")
         self.assertEqual(account.last_fetch_status, "SUCCESS")
 
+    # ==========================================
+    # Interactive-login "returns data directly" coverage for assisted-mode plugins
+    # (aircanada, american, ana, asiana, avianca, caesars, enterprise, eva, hertz,
+    # hilton, ihg, korean, marriott, national, southwest, united, virgin).
+    #
+    # Each plugin's interactive_login() runs a polling loop that, once it detects a
+    # successful login (via a URL check, element visibility, or similar site-specific
+    # signal), calls that plugin's own extraction helper(s) and returns a dict rather
+    # than None. These tests mock the browser (SB) and patch each plugin's extraction
+    # helper(s) directly -- not the raw HTML/DOM -- since the extraction logic itself
+    # is already covered by each plugin's existing fetch_data() tests. The goal here
+    # is narrower: confirm interactive_login() correctly detects success and returns
+    # the extracted data in the same run, per the reviewer's request on PR #120.
+    # ==========================================
+
+    def _mock_sb(self, current_url="https://example.com/", page_source="<html></html>"):
+        """Builds a MagicMock simulating an `sb` instance plus the context manager
+        wrapper matching `with SB(...) as sb:` usage in interactive_login()."""
+        from unittest.mock import MagicMock
+        mock_sb = MagicMock()
+        mock_sb.get_current_url.return_value = current_url
+        mock_sb.get_page_source.return_value = page_source
+        mock_sb.is_element_visible.return_value = False
+        mock_sb.is_element_present.return_value = False
+
+        mock_context = MagicMock()
+        mock_context.__enter__.return_value = mock_sb
+        mock_context.__exit__.return_value = False
+        return mock_sb, mock_context
+
+    def test_hilton_interactive_login_returns_data(self):
+        from unittest.mock import patch
+        plugin = plugin_manager.get_plugin('hilton')
+        mock_sb, mock_context = self._mock_sb()
+
+        with patch('plugins.hilton.SB', return_value=mock_context), \
+             patch.object(plugin, '_extract_data', return_value=(5000, 'Gold', datetime(2026, 1, 1))):
+            result = plugin.interactive_login('user', 'pass', profile_dir=None)
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result['balance'], 5000)
+        self.assertEqual(result['status'], 'Gold')
+
+    def test_united_interactive_login_returns_data(self):
+        from unittest.mock import patch
+        plugin = plugin_manager.get_plugin('united')
+        mock_sb, mock_context = self._mock_sb(current_url="https://www.united.com/en/us/myunited")
+
+        with patch('plugins.united.SB', return_value=mock_context), \
+             patch.object(plugin, '_extract_data', return_value=(12345, 'Premier Gold')):
+            result = plugin.interactive_login('user', 'pass', profile_dir=None)
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result['balance'], 12345)
+        self.assertEqual(result['status'], 'Premier Gold')
+
+    def test_national_interactive_login_returns_data(self):
+        from unittest.mock import patch
+        plugin = plugin_manager.get_plugin('national')
+        mock_sb, mock_context = self._mock_sb()
+
+        with patch('plugins.national.SB', return_value=mock_context), \
+             patch.object(plugin, '_extract_data', return_value=(1000, 'Silver', datetime(2026, 1, 1))):
+            result = plugin.interactive_login('user', 'pass', profile_dir=None)
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result['balance'], 1000)
+        self.assertEqual(result['status'], 'Silver')
+
+    def test_american_interactive_login_returns_data(self):
+        from unittest.mock import patch
+        plugin = plugin_manager.get_plugin('american')
+        mock_sb, mock_context = self._mock_sb(
+            current_url="https://www.aa.com/aadvantage-program/profile/account-summary"
+        )
+
+        with patch('plugins.american.SB', return_value=mock_context), \
+             patch.object(plugin, '_extract_data', return_value=(5000, 'Gold', None, None)):
+            result = plugin.interactive_login('user', 'pass', profile_dir=None)
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result['balance'], 5000)
+        self.assertEqual(result['status'], 'Gold')
+
+    def test_ihg_interactive_login_returns_data(self):
+        from unittest.mock import patch
+        plugin = plugin_manager.get_plugin('ihg')
+        mock_sb, mock_context = self._mock_sb(
+            current_url="https://www.ihg.com/rewardsclub/us/en/account-mgmt/home"
+        )
+
+        with patch('plugins.ihg.SB', return_value=mock_context), \
+             patch.object(plugin, '_extract_data', return_value=(3000, 'Gold Elite')):
+            result = plugin.interactive_login('user', 'pass', profile_dir=None)
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result['balance'], 3000)
+        self.assertEqual(result['status'], 'Gold Elite')
+
+    def test_southwest_interactive_login_returns_data(self):
+        from unittest.mock import patch
+        plugin = plugin_manager.get_plugin('southwest')
+        mock_sb, mock_context = self._mock_sb(current_url="https://www.southwest.com/loyalty/myaccount/")
+
+        with patch('plugins.southwest.SB', return_value=mock_context), \
+             patch.object(plugin, '_extract_data_from_page', return_value=(2000, 'A-List')):
+            result = plugin.interactive_login('user', 'pass', profile_dir=None)
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result['balance'], 2000)
+        self.assertEqual(result['status'], 'A-List')
+
+    def test_avianca_interactive_login_returns_data(self):
+        from unittest.mock import patch
+        plugin = plugin_manager.get_plugin('avianca')
+        mock_sb, mock_context = self._mock_sb(current_url="https://www.lifemiles.com/account/overview")
+
+        with patch('plugins.avianca.SB', return_value=mock_context), \
+             patch.object(plugin, '_extract_data', return_value=(15000, 'Clásico Plus')), \
+             patch.object(plugin, '_extract_expiration_date', return_value=None):
+            result = plugin.interactive_login('user', 'pass', profile_dir=None)
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result['balance'], 15000)
+        self.assertEqual(result['status'], 'Clásico Plus')
+
+    def test_aircanada_interactive_login_returns_data(self):
+        from unittest.mock import patch
+        plugin = plugin_manager.get_plugin('aircanada')
+        mock_sb, mock_context = self._mock_sb(
+            current_url="https://www.aircanada.com/aeroplan/member/dashboard"
+        )
+
+        with patch('plugins.aircanada.SB', return_value=mock_context), \
+             patch.object(plugin, '_extract_data', return_value=(8000, 'Prestige 25K', None)):
+            result = plugin.interactive_login('user', 'pass', profile_dir=None)
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result['balance'], 8000)
+        self.assertEqual(result['status'], 'Prestige 25K')
+
+    def test_marriott_interactive_login_returns_data(self):
+        from unittest.mock import patch
+        plugin = plugin_manager.get_plugin('marriott')
+        mock_sb, mock_context = self._mock_sb(
+            current_url="https://www.marriott.com/en/loyalty/myAccount/default.mi"
+        )
+
+        with patch('plugins.marriott.SB', return_value=mock_context), \
+             patch.object(plugin, '_extract_from_datalayer', return_value=(6000, 'Titanium Elite')), \
+             patch.object(plugin, '_extract_expiration_date', return_value=None):
+            result = plugin.interactive_login('user', 'pass', profile_dir=None)
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result['balance'], 6000)
+        self.assertEqual(result['status'], 'Titanium Elite')
+
+    def test_enterprise_interactive_login_returns_data(self):
+        from unittest.mock import patch
+        plugin = plugin_manager.get_plugin('enterprise')
+        mock_sb, mock_context = self._mock_sb()
+
+        with patch('plugins.enterprise.SB', return_value=mock_context), \
+             patch.object(plugin, '_extract_data', return_value=(500, 'Plus', None)):
+            result = plugin.interactive_login('user', 'pass', profile_dir=None)
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result['balance'], 500)
+        self.assertEqual(result['status'], 'Plus')
+
+    def test_hertz_interactive_login_returns_data(self):
+        from unittest.mock import patch
+        plugin = plugin_manager.get_plugin('hertz')
+        mock_sb, mock_context = self._mock_sb(current_url="https://www.hertz.com/rentacar/emember/profile.do")
+
+        with patch('plugins.hertz.SB', return_value=mock_context), \
+             patch.object(plugin, '_extract_data', return_value=(700, 'Five Star', None)):
+            result = plugin.interactive_login('user', 'pass', profile_dir=None)
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result['balance'], 700)
+        self.assertEqual(result['status'], 'Five Star')
+
+    def test_caesars_interactive_login_returns_data(self):
+        from unittest.mock import patch
+        plugin = plugin_manager.get_plugin('caesars')
+        mock_sb, mock_context = self._mock_sb(current_url="https://www.caesars.com/myrewards/profile/")
+
+        with patch('plugins.caesars.SB', return_value=mock_context), \
+             patch.object(plugin, '_extract_data', return_value=(900, 'Diamond', None)):
+            result = plugin.interactive_login('user', 'pass', profile_dir=None)
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result['balance'], 900)
+        self.assertEqual(result['status'], 'Diamond')
+
+    def test_virgin_interactive_login_returns_data(self):
+        from unittest.mock import patch
+        plugin = plugin_manager.get_plugin('virgin')
+        mock_sb, mock_context = self._mock_sb(
+            current_url="https://www.virginatlantic.com/flying-club/account/overview"
+        )
+
+        with patch('plugins.virgin.SB', return_value=mock_context), \
+             patch.object(plugin, '_extract_data', return_value=(25000, 'Gold')):
+            result = plugin.interactive_login('user', 'pass', profile_dir=None)
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result['balance'], 25000)
+        self.assertEqual(result['status'], 'Gold')
+
+    def test_ana_interactive_login_returns_data(self):
+        from unittest.mock import patch
+        plugin = plugin_manager.get_plugin('ana')
+        mock_sb, mock_context = self._mock_sb()
+        canned_result = {'balance': 4000, 'status': 'Bronze', 'expiration_date': None, 'certificates': []}
+
+        with patch('plugins.ana.SB', return_value=mock_context), \
+             patch.object(plugin, '_check_logged_in', return_value=True), \
+             patch.object(plugin, '_parse_mileage_html', return_value=canned_result), \
+             patch.object(plugin, '_fetch_expiration', return_value=None):
+            result = plugin.interactive_login('user', 'pass', profile_dir=None)
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result['balance'], 4000)
+        self.assertEqual(result['status'], 'Bronze')
+
+    def test_asiana_interactive_login_returns_data(self):
+        from unittest.mock import patch
+        plugin = plugin_manager.get_plugin('asiana')
+        mock_sb, mock_context = self._mock_sb(current_url="https://flyasiana.com/my-asiana/dashboard")
+        canned_result = {'balance': 3500, 'status': 'Silver', 'expiration_date': None, 'certificates': []}
+
+        with patch('plugins.asiana.SB', return_value=mock_context), \
+             patch.object(plugin, '_parse_mileage_html', return_value=canned_result), \
+             patch.object(plugin, '_fetch_expiration', return_value=None):
+            result = plugin.interactive_login('user', 'pass', profile_dir=None)
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result['balance'], 3500)
+        self.assertEqual(result['status'], 'Silver')
+
+    def test_eva_interactive_login_returns_data(self):
+        from unittest.mock import patch
+        plugin = plugin_manager.get_plugin('eva')
+        mock_sb, mock_context = self._mock_sb(
+            current_url="https://eservice.evaair.com/flyeva/eva/ffp/frequent-flyer.aspx"
+        )
+        canned_result = {'balance': 6500, 'status': 'Gold', 'expiration_date': None, 'certificates': []}
+
+        with patch('plugins.eva.SB', return_value=mock_context), \
+             patch.object(plugin, '_check_logged_in', return_value=True), \
+             patch.object(plugin, '_parse_account_html', return_value=canned_result):
+            result = plugin.interactive_login('user', 'pass', profile_dir=None)
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result['balance'], 6500)
+        self.assertEqual(result['status'], 'Gold')
+
+    def test_korean_interactive_login_returns_data(self):
+        from unittest.mock import patch, mock_open
+        plugin = plugin_manager.get_plugin('korean')
+        mock_sb, mock_context = self._mock_sb(
+            current_url="https://www.koreanair.com/us/en/my-mileage/overview",
+            page_source='<html><body><span class="mileage-my__point">7777</span></body></html>'
+        )
+        canned_result = {'balance': 7777, 'status': 'Morning Calm Premium', 'expiration_date': None, 'certificates': []}
+
+        with patch('plugins.korean.SB', return_value=mock_context), \
+             patch.object(plugin, '_parse_mileage_html', return_value=canned_result), \
+             patch.object(plugin, '_fetch_korean_expiration_data', return_value=(None, None)), \
+             patch.object(plugin, '_fetch_korean_coupon_data', return_value=[]), \
+             patch('builtins.open', mock_open()):
+            result = plugin.interactive_login('user', 'pass', profile_dir=None)
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result['balance'], 7777)
+        self.assertEqual(result['status'], 'Morning Calm Premium')
+
     def test_dashboard_renders_generic_sync_failure_both_options(self):
         # Create an account with a generic/vague failure
         account = Account(


### PR DESCRIPTION
## Summary
- Interactive Login only established a session; the app then required a separate "Sync Now" click that launched a second browser and re-authenticated — which can fail on sites that gate every login behind MFA, since no human is present for that second attempt.
- For assisted-mode plugins, which already extract balance/status from the open, authenticated session just to detect login success, that scraped data was being discarded instead of returned. It's now returned directly and persisted in the same flow. Applies to: Virgin Atlantic, Air Canada, American, ANA, Asiana, Avianca, Caesars, Enterprise, EVA, Hertz, Hilton, IHG, Korean Air, Marriott, National, Southwest, and United.
- `app.py` also gets a missing `db.session.rollback()` so a failed post-login sync can't commit a half-applied database change.
- Virgin Atlantic additionally gets explicit JSON cookie save/load, since relying on SeleniumBase's `uc=True` + `user_data_dir` alone to carry a session across separate browser launches proved unreliable for a program requiring MFA on every login.
- A few plugins (Marriott, United, Air Canada, Avianca, Hilton) needed more than a bare return, since their success detection didn't always have a usable balance/last-activity-date in scope yet. Marriott's version also fixes two latent bugs found in review: a failed post-login balance re-scrape could silently persist `balance=0` to the account instead of erroring, and a status fallback could persist an empty string instead of "Unknown".
- Avianca gets several additional fixes found via live testing: a zero balance was being treated as "not found" by an overly strict numeric-value guard; its transactions-page URL list was stale and its "did we land somewhere real" check produced false positives (matching the URL string even on that URL's own 404 page, and separately matching error-sounding text embedded in the site's JS bundle rather than the rendered page). Interactive login no longer visits the transactions page at all — the expiration date is already reliably shown on the account overview page it's already scraping.

## Test plan
- [x] Full test suite passes (166 passed, 3 skipped) except one pre-existing, unrelated failure (`TestMarriottExpirationParsing::test_explicit_english_iso_expiration`, confirmed present on `main` before this branch — a date-relative test issue unaffected by this change)
- [x] All 31 plugins load cleanly via the plugin manager
- [x] Manually verified end-to-end against live accounts, including iterating on the Avianca-specific fixes against the real site