### PR TITLE
fix(interactive-login): capture data immediately for Alaska, Delta, Hyatt, and JAL

### DIFF
--- a/app.py
+++ b/app.py
@@ -1208,6 +1208,7 @@ def create_app(config_class=Config):
         password = security_manager.decrypt(account.password_encrypted)
         profile_dir = os.path.join(app.config.get('ROOT_DIR', os.getcwd()), 'browser_profiles', str(account.id))
 
+        from plugins.base import is_cancelled
         try:
             app_log.info(f"Starting interactive login for account {account.display_name}...")
             login_result = safe_call_plugin_method(
@@ -1223,7 +1224,24 @@ def create_app(config_class=Config):
             app_log.info(f"Interactive login completed for {account.display_name}.")
         except Exception as e:
             app_log.error(f"Interactive login failed for {account.display_name}: {str(e)}", exc_info=True)
-            flash(f'Interactive login failed for {account.display_name}: {str(e)}')
+            if is_cancelled(account.id):
+                flash(f'Interactive login for {account.display_name} was cancelled.')
+            else:
+                flash(f'Interactive login failed for {account.display_name}: {str(e)}')
+            referrer = request.referrer
+            if referrer and ('/accounts/' in referrer) and ('/edit' not in referrer):
+                return redirect(referrer)
+            return redirect(url_for('index'))
+
+        # If the user cancelled mid-login, some plugins' own broad except blocks
+        # swallow the resulting cancellation error and return None rather than
+        # re-raising it -- which would otherwise be indistinguishable from "this
+        # plugin can't scrape mid-login, please fall back to fetch_data()" below.
+        # Check the cancellation flag explicitly so a cancelled run doesn't
+        # silently launch an entirely new, unprotected browser session anyway.
+        if is_cancelled(account.id):
+            app_log.info(f"Interactive login cancelled by user for {account.display_name}.")
+            flash(f'Interactive login for {account.display_name} was cancelled.')
             referrer = request.referrer
             if referrer and ('/accounts/' in referrer) and ('/edit' not in referrer):
                 return redirect(referrer)
@@ -1257,6 +1275,10 @@ def create_app(config_class=Config):
             send_desktop_notification("Sync Successful", f"{account.display_name} balance updated successfully to {account.balance:,} points.")
             flash(f'{account.display_name} logged in and synced successfully.')
         except Exception as e:
+            # Discard any partial mutations _persist_fetch_result staged before raising
+            # (e.g. balance/status already set, old certificates marked for deletion)
+            # so only the FAILED status below gets committed, not a half-applied sync.
+            db.session.rollback()
             account.last_fetch_status = 'FAILED'
             account.last_error = str(e)
             account.last_updated = datetime.utcnow()

--- a/plugins/alaska.py
+++ b/plugins/alaska.py
@@ -1,7 +1,9 @@
-from typing import Dict, Any
+from typing import Dict, Any, Optional, Tuple
 from datetime import datetime
 from .base import ProviderPlugin, PluginError, InteractionRequiredError, get_sb_kwargs
 from seleniumbase import SB
+from bs4 import BeautifulSoup
+import re
 import time
 
 class AlaskaAirlinesPlugin(ProviderPlugin):
@@ -152,6 +154,110 @@ class AlaskaAirlinesPlugin(ProviderPlugin):
         except Exception as e:
             print(f"Error restoring Alaska Airlines cookies: {e}")
 
+    def _extract_balance_status(self, html: str) -> Tuple[Optional[int], str]:
+        """Parses Mileage Plan points balance and tier status from dashboard HTML."""
+        soup = BeautifulSoup(html, "html.parser")
+
+        balance = None
+        status = "Member"
+
+        # 1. Search by points-value class (direct and robust on modern dashboard)
+        points_val_el = soup.find(class_=re.compile(r"points-value"))
+        if points_val_el:
+            text_val = points_val_el.text.strip().replace(",", "")
+            if text_val.isdigit():
+                balance = int(text_val)
+                print(f"Found balance via points-value class: {balance}")
+
+        # 2. Look for "Available Points" or "Available Miles" (legacy/alternative layouts)
+        if balance is None:
+            avail_texts = soup.find_all(string=re.compile(r"Available Points|Available Miles|Total Miles", re.I))
+            for at in avail_texts:
+                parent = at.parent
+                if not parent:
+                    continue
+
+                # Check sibling elements in parent container
+                parent_container = parent.parent
+                if parent_container:
+                    sibling_val = parent_container.find(class_=re.compile(r"points-value|display-sm|display-xs"))
+                    if sibling_val:
+                        text_val = sibling_val.text.strip().replace(",", "")
+                        if text_val.isdigit():
+                            balance = int(text_val)
+                            break
+
+                parent_text = parent.text.strip()
+                grandparent_text = parent_container.text.strip() if parent_container else ""
+
+                matches = re.findall(r"([\d,]+)\s*Available", parent_text, re.I)
+                if not matches:
+                    matches = re.findall(r"([\d,]+)\s*Available", grandparent_text, re.I)
+                if not matches:
+                    matches = re.findall(r"([\d,]+)", parent_text)
+                if not matches:
+                    matches = re.findall(r"([\d,]+)", grandparent_text)
+
+                for m in matches:
+                    clean_m = m.replace(",", "")
+                    if clean_m.isdigit():
+                        balance = int(clean_m)
+                        break
+                if balance is not None:
+                    break
+
+        # 3. Look for specific class 'display-xs' as fallback
+        if balance is None:
+            spans = soup.find_all(class_="display-xs")
+            for span in spans:
+                text_val = span.text.strip().replace(",", "")
+                if text_val.isdigit() and len(text_val) < 8:
+                    balance = int(text_val)
+                    break
+
+        # Check tier status. Alaska rebranded Mileage Plan's MVP tiers to Atmos
+        # Rewards (Atmos Silver/Gold/Platinum/Titanium -- see
+        # https://www.alaskaair.com/atmosrewards/content/faq/status), but legacy
+        # "MVP Gold 75K/100K" wording can still appear for grandfathered members,
+        # so both naming schemes are recognized. A bare "Gold"/"Platinum"/etc.
+        # mention (no "MVP" prefix) is treated as the current Atmos branding,
+        # since that's what the live dashboard shows going forward.
+        tier_rank = {
+            "Member": 0, "Atmos Member": 1, "MVP": 2, "Atmos Silver": 3,
+            "MVP Gold": 4, "Atmos Gold": 4, "MVP Gold 75K": 5, "Atmos Platinum": 5,
+            "MVP Gold 100K": 6, "Atmos Titanium": 6,
+        }
+        tier_texts = soup.find_all(string=re.compile(r"MVP|Atmos", re.I))
+        for t in tier_texts:
+            t_str = t.strip()
+            if len(t_str) >= 50:
+                continue
+
+            candidate = None
+            if "100K" in t_str:
+                candidate = "MVP Gold 100K"
+            elif "75K" in t_str:
+                candidate = "MVP Gold 75K"
+            elif "Titanium" in t_str:
+                candidate = "Atmos Titanium"
+            elif "Platinum" in t_str:
+                candidate = "Atmos Platinum"
+            elif "MVP Gold" in t_str:
+                candidate = "MVP Gold"
+            elif "Gold" in t_str:
+                candidate = "Atmos Gold"
+            elif "Silver" in t_str:
+                candidate = "Atmos Silver"
+            elif "MVP" in t_str:
+                candidate = "MVP"
+            elif "Atmos" in t_str or "ATMOS REWARDS MEMBER" in t_str.upper():
+                candidate = "Atmos Member"
+
+            if candidate and tier_rank.get(candidate, -1) > tier_rank.get(status, -1):
+                status = candidate
+
+        return balance, status
+
     def fetch_data(self, username: str, password: str, profile_dir: str = None) -> Dict[str, Any]:
         try:
             agent = self.get_consistent_user_agent()
@@ -263,84 +369,8 @@ class AlaskaAirlinesPlugin(ProviderPlugin):
                     
                 sb.sleep(2)
                 html = sb.get_page_source()
-                from bs4 import BeautifulSoup
-                import re
-                soup = BeautifulSoup(html, "html.parser")
-                
-                balance = None
-                status = "Member"
-                
-                # 1. Search by points-value class (direct and robust on modern dashboard)
-                points_val_el = soup.find(class_=re.compile(r"points-value"))
-                if points_val_el:
-                    text_val = points_val_el.text.strip().replace(",", "")
-                    if text_val.isdigit():
-                        balance = int(text_val)
-                        print(f"Found balance via points-value class: {balance}")
-                
-                # 2. Look for "Available Points" or "Available Miles" (legacy/alternative layouts)
-                if balance is None:
-                    avail_texts = soup.find_all(string=re.compile(r"Available Points|Available Miles|Total Miles", re.I))
-                    for at in avail_texts:
-                        parent = at.parent
-                        if not parent:
-                            continue
-                        
-                        # Check sibling elements in parent container
-                        parent_container = parent.parent
-                        if parent_container:
-                            sibling_val = parent_container.find(class_=re.compile(r"points-value|display-sm|display-xs"))
-                            if sibling_val:
-                                text_val = sibling_val.text.strip().replace(",", "")
-                                if text_val.isdigit():
-                                    balance = int(text_val)
-                                    break
-                                    
-                        parent_text = parent.text.strip()
-                        grandparent_text = parent_container.text.strip() if parent_container else ""
-                        
-                        matches = re.findall(r"([\d,]+)\s*Available", parent_text, re.I)
-                        if not matches:
-                            matches = re.findall(r"([\d,]+)\s*Available", grandparent_text, re.I)
-                        if not matches:
-                            matches = re.findall(r"([\d,]+)", parent_text)
-                        if not matches:
-                            matches = re.findall(r"([\d,]+)", grandparent_text)
-                        
-                        for m in matches:
-                            clean_m = m.replace(",", "")
-                            if clean_m.isdigit():
-                                balance = int(clean_m)
-                                break
-                        if balance is not None:
-                            break
-                            
-                # 3. Look for specific class 'display-xs' as fallback
-                if balance is None:
-                    spans = soup.find_all(class_="display-xs")
-                    for span in spans:
-                        text_val = span.text.strip().replace(",", "")
-                        if text_val.isdigit() and len(text_val) < 8:
-                            balance = int(text_val)
-                            break
-                            
-                # Check tier status
-                tier_texts = soup.find_all(string=re.compile(r"MVP|Atmos™ Member|Member|ATMOS REWARDS MEMBER", re.I))
-                for t in tier_texts:
-                    t_str = t.strip()
-                    if len(t_str) < 50:
-                        if "100K" in t_str:
-                            status = "MVP Gold 100K"
-                            break
-                        elif "75K" in t_str and status != "MVP Gold 100K":
-                            status = "MVP Gold 75K"
-                        elif "Gold" in t_str and status not in ["MVP Gold 100K", "MVP Gold 75K"]:
-                            status = "MVP Gold"
-                        elif "MVP" in t_str and status not in ["MVP Gold 100K", "MVP Gold 75K", "MVP Gold"]:
-                            status = "MVP"
-                        elif ("Atmos" in t_str or "ATMOS REWARDS MEMBER" in t_str.upper()) and status == "Member":
-                            status = "Atmos Member"
-                
+                balance, status = self._extract_balance_status(html)
+
                 if balance is None:
                     raise PluginError("Could not find balance on the Alaska Airlines dashboard.")
                 
@@ -364,7 +394,7 @@ class AlaskaAirlinesPlugin(ProviderPlugin):
             raise PluginError(f"Alaska Airlines scraping failed: {e}")
 
 
-    def interactive_login(self, username: str, password: str, profile_dir: str = None) -> None:
+    def interactive_login(self, username: str, password: str, profile_dir: str = None) -> Optional[Dict[str, Any]]:
         try:
             agent = self.get_consistent_user_agent()
             with SB(**get_sb_kwargs(uc=True, headless=False, user_data_dir=profile_dir, agent=agent)) as sb:
@@ -395,18 +425,19 @@ class AlaskaAirlinesPlugin(ProviderPlugin):
                     print(f"Error pre-filling Alaska Auth0 credentials: {e}")
                     
                 print("Please log in manually if needed. Waiting for the dashboard URL...")
+                success = False
                 try:
                     for _ in range(60):  # Wait up to 5 minutes
                         current_url = sb.get_current_url()
                         # Help the user by auto-clicking any "Not now" or "Skip" MFA buttons
                         if not self.is_mfa_challenge(sb, current_url):
                             for selector in [
-                                "button:contains('Not now')", 
-                                "a:contains('Not now')", 
-                                "button:contains('Skip')", 
-                                "a:contains('Skip')", 
-                                "button:contains('Skip for now')", 
-                                "a:contains('Skip for now')", 
+                                "button:contains('Not now')",
+                                "a:contains('Not now')",
+                                "button:contains('Skip')",
+                                "a:contains('Skip')",
+                                "button:contains('Skip for now')",
+                                "a:contains('Skip for now')",
                                 "button:contains('No, thanks')",
                                 "a:contains('No, thanks')",
                                 "button:contains('Remind me later')",
@@ -417,7 +448,7 @@ class AlaskaAirlinesPlugin(ProviderPlugin):
                                     sb.click(selector)
                                     sb.sleep(2)
                                     break
-                                
+
                         current_url = sb.get_current_url()
                         if "myaccount" in current_url.lower() or "mileage-plan" in current_url.lower() or "atmosrewards" in current_url.lower():
                             if not self.is_auth_url(current_url):
@@ -428,9 +459,39 @@ class AlaskaAirlinesPlugin(ProviderPlugin):
                                         self.save_cookies_to_json(sb, profile_dir)
                                     except Exception:
                                         pass
+                                success = True
                                 break
                         sb.sleep(5)
                 except Exception as e:
                     print(f"Interactive login wait interrupted: {e}")
+
+                if not success:
+                    return None
+
+                # Wait for balance-bearing elements to render, matching fetch_data()'s
+                # dashboard-load polling -- a single fixed sleep isn't reliable on a
+                # slower render of this React SPA.
+                for _ in range(15):
+                    if (sb.is_element_visible("div:contains('Available')") or
+                        sb.is_element_visible("div.display-xs") or
+                        sb.is_element_visible(".points-value") or
+                        sb.is_element_visible("div.points-value") or
+                        sb.is_element_visible("div.points-label")):
+                        break
+                    sb.sleep(2)
+
+                html = sb.get_page_source()
+                balance, status = self._extract_balance_status(html)
+                if balance is None:
+                    raise PluginError("Logged in successfully, but could not find balance on the Alaska Airlines dashboard.")
+
+                return {
+                    "balance": balance,
+                    "status": status,
+                    "expiration_date": None
+                }
+        except PluginError:
+            raise
         except Exception as e:
             print(f"Interactive login error: {e}")
+            return None

--- a/plugins/base.py
+++ b/plugins/base.py
@@ -9,6 +9,27 @@ from seleniumbase import BaseCase
 active_drivers = {}
 active_drivers_lock = threading.Lock()
 
+# Accounts whose active browser session was cancelled by the user. Checked by
+# the patched SeleniumBase methods below so a cancelled run stops making
+# Selenium calls entirely, instead of relying solely on the killed browser
+# process to raise an exception -- uc=True mode has its own reconnect/resilience
+# machinery that can otherwise silently relaunch a fresh Chrome window after the
+# original one is killed, making cancellation look like it didn't work.
+cancelled_accounts = set()
+cancelled_accounts_lock = threading.Lock()
+
+def mark_cancelled(account_id) -> None:
+    with cancelled_accounts_lock:
+        cancelled_accounts.add(account_id)
+
+def is_cancelled(account_id) -> bool:
+    with cancelled_accounts_lock:
+        return account_id in cancelled_accounts
+
+def clear_cancelled(account_id) -> None:
+    with cancelled_accounts_lock:
+        cancelled_accounts.discard(account_id)
+
 
 def get_chrome_binary() -> str | None:
     """
@@ -132,14 +153,65 @@ def cancel_active_driver(account_id) -> bool:
     with active_drivers_lock:
         sb = active_drivers.get(account_id)
     if sb:
+        # Mark cancelled first so the patched methods below refuse to make any
+        # further Selenium calls even if killing the process races with the
+        # running plugin thread's next call.
+        mark_cancelled(account_id)
         try:
             if hasattr(sb, 'driver') and sb.driver:
                 sb.driver.quit()
             elif hasattr(sb, 'quit'):
                 sb.quit()
-            return True
         except Exception:
-            return True
+            pass
+
+        # driver.quit() doesn't always fully terminate the underlying Chrome
+        # process in uc=True headed mode, which can leave a still-running,
+        # still-navigating window behind that looks like cancel did nothing
+        # (or that the window "popped back up"). Force-kill any Chrome process
+        # tied to this account's browser profile as a fallback, mirroring
+        # wait_for_chrome_exit()'s psutil-with-subprocess-fallback approach
+        # (psutil isn't an actual dependency of this project).
+        import os
+        import platform
+        import subprocess
+        profile_marker = os.path.join('browser_profiles', str(account_id)).lower()
+        try:
+            import psutil
+            for proc in psutil.process_iter(['name', 'cmdline']):
+                try:
+                    if proc.info['name'] and 'chrome' in proc.info['name'].lower():
+                        cmdline = proc.info['cmdline']
+                        if cmdline and profile_marker in ' '.join(cmdline).lower():
+                            proc.kill()
+                except (psutil.NoSuchProcess, psutil.AccessDenied):
+                    pass
+        except ImportError:
+            try:
+                if platform.system() == "Windows":
+                    escaped_marker = profile_marker.replace("'", "''")
+                    cmd = f"Get-CimInstance Win32_Process | Where-Object {{ $_.Name -like '*chrome*' -and $_.CommandLine -like '*{escaped_marker}*' }} | ForEach-Object {{ Stop-Process -Id $_.ProcessId -Force }}"
+                    subprocess.run(["powershell", "-NoProfile", "-Command", cmd], capture_output=True)
+                else:
+                    output = subprocess.check_output(
+                        "ps -ef | grep -i chrome | grep -v grep",
+                        shell=True,
+                        stderr=subprocess.DEVNULL
+                    ).decode(errors='ignore')
+                    for line in output.splitlines():
+                        if profile_marker in line.lower():
+                            parts = line.split()
+                            if len(parts) > 1:
+                                try:
+                                    os.kill(int(parts[1]), 9)
+                                except Exception:
+                                    pass
+            except Exception:
+                pass
+        except Exception:
+            pass
+
+        return True
     return False
 
 def is_hidden_node(node) -> bool:
@@ -345,7 +417,17 @@ def _apply_selenium_patches():
                         import debug_logger
                     except ImportError:
                         return orig_method(self, *args, **kwargs)
-                        
+
+                    # If the user cancelled this account's session, refuse to make
+                    # any further Selenium calls at all -- including this one --
+                    # rather than letting a dead/killed browser's next call reach
+                    # uc=True mode's own reconnect/resilience logic, which can
+                    # otherwise silently relaunch a fresh Chrome window and make
+                    # cancellation appear to not have worked.
+                    cancel_account_id = getattr(debug_logger._log_context, 'account_id', None)
+                    if cancel_account_id and is_cancelled(cancel_account_id):
+                        raise PluginError("Cancelled by user.")
+
                     # Re-entry guard to prevent recursion if screenshot/html methods trigger wrappers
                     in_logger = getattr(debug_logger._log_context, 'in_logger', False)
                     if in_logger:
@@ -614,7 +696,12 @@ def safe_call_plugin_method(method, *args, **kwargs):
     account_id = kwargs.pop('_account_id', None)
     provider_name = kwargs.pop('_provider_name', None)
     current_balance = kwargs.pop('_current_balance', None)
-    
+
+    # A new run is starting for this account -- clear any stale cancellation
+    # flag from a previous run so this one isn't refused before it starts.
+    if account_id:
+        clear_cancelled(account_id)
+
     # Initialize debug log context if metadata is provided
     try:
         import debug_logger

--- a/plugins/delta.py
+++ b/plugins/delta.py
@@ -1,6 +1,8 @@
-from typing import Dict, Any
+from typing import Dict, Any, Optional, Tuple
 from .base import ProviderPlugin, PluginError, InteractionRequiredError, get_sb_kwargs
 from seleniumbase import SB
+from bs4 import BeautifulSoup
+import re
 import time
 
 class DeltaSkyMilesPlugin(ProviderPlugin):
@@ -38,6 +40,47 @@ class DeltaSkyMilesPlugin(ProviderPlugin):
                     sb.sleep(0.5)
             except Exception:
                 pass
+
+    def _extract_balance_status(self, html: str) -> Tuple[Optional[int], str]:
+        """Parses SkyMiles balance and tier status from dashboard HTML."""
+        soup = BeautifulSoup(html, "html.parser")
+
+        balance = None
+        status = "Member"
+
+        # For Delta, the balance is usually under a class or nearby "Miles Available"
+        mile_texts = soup.find_all(string=re.compile(r"Miles Available|Available Miles|Total Miles|SkyMiles Balance", re.I))
+        for mt in mile_texts:
+            parent = mt.parent
+            if parent and parent.parent:
+                text_content = parent.parent.text.strip()
+                # specifically exclude 10-digit account numbers from the match
+                matches = re.findall(r"(?:^|\s|AVAILABLE\s*)([\d,]{2,})(?:\s|$)", text_content)
+                for m in matches:
+                    clean_m = m.replace(",", "")
+                    if len(clean_m) != 10: # Account numbers are 10 digits
+                        balance = int(clean_m)
+                        break
+            if balance is not None:
+                break
+
+        if balance is None:
+            # Try looking for specific classes found in Delta's Angular application
+            possible_elements = soup.find_all(class_=re.compile(r"mile.*val|balance.*val|skymiles-balance|skymiles-wrapper__subtitle|content__number", re.I))
+            for elem in possible_elements:
+                parent_text = elem.parent.text.upper() if elem.parent else ""
+                if "LIFETIME" in parent_text:
+                    continue # Skip lifetime miles
+
+                text = elem.text.strip()
+                matches = re.findall(r"([\d,]+)", text)
+                if matches:
+                    clean_m = matches[0].replace(",", "")
+                    if len(clean_m) != 10:
+                        balance = int(clean_m)
+                        break
+
+        return balance, status
 
     def fetch_data(self, username: str, password: str, profile_dir: str = None) -> Dict[str, Any]:
         with SB(**get_sb_kwargs(uc=True, user_data_dir=profile_dir)) as sb:
@@ -137,46 +180,9 @@ class DeltaSkyMilesPlugin(ProviderPlugin):
                 html = sb.get_page_source()
                 with open("delta_dashboard_debug.html", "w", encoding="utf-8") as f:
                     f.write(html)
-                    
-                from bs4 import BeautifulSoup
-                import re
-                soup = BeautifulSoup(html, "html.parser")
-                
-                balance = None
-                status = "Member"
-                
-                # For Delta, the balance is usually under a class or nearby "Miles Available"
-                mile_texts = soup.find_all(string=re.compile(r"Miles Available|Available Miles|Total Miles|SkyMiles Balance", re.I))
-                for mt in mile_texts:
-                    parent = mt.parent
-                    if parent and parent.parent:
-                        text_content = parent.parent.text.strip()
-                        # specifically exclude 10-digit account numbers from the match
-                        matches = re.findall(r"(?:^|\s|AVAILABLE\s*)([\d,]{2,})(?:\s|$)", text_content)
-                        for m in matches:
-                            clean_m = m.replace(",", "")
-                            if len(clean_m) != 10: # Account numbers are 10 digits
-                                balance = int(clean_m)
-                                break
-                    if balance is not None:
-                        break
-                                
-                if balance is None:
-                    # Try looking for specific classes found in Delta's Angular application
-                    possible_elements = soup.find_all(class_=re.compile(r"mile.*val|balance.*val|skymiles-balance|skymiles-wrapper__subtitle|content__number", re.I))
-                    for elem in possible_elements:
-                        parent_text = elem.parent.text.upper() if elem.parent else ""
-                        if "LIFETIME" in parent_text:
-                            continue # Skip lifetime miles
-                            
-                        text = elem.text.strip()
-                        matches = re.findall(r"([\d,]+)", text)
-                        if matches:
-                            clean_m = matches[0].replace(",", "")
-                            if len(clean_m) != 10:
-                                balance = int(clean_m)
-                                break
-                                
+
+                balance, status = self._extract_balance_status(html)
+
                 if balance is None:
                     raise PluginError("Could not find SkyMiles balance on the Delta dashboard. Check delta_dashboard_debug.html")
 
@@ -188,23 +194,72 @@ class DeltaSkyMilesPlugin(ProviderPlugin):
             except Exception as e:
                 raise PluginError(f"Delta scraping failed: {e}")
 
-    def interactive_login(self, username: str, password: str, profile_dir: str = None) -> None:
+    def interactive_login(self, username: str, password: str, profile_dir: str = None) -> Optional[Dict[str, Any]]:
         with SB(**get_sb_kwargs(uc=True, user_data_dir=profile_dir)) as sb:
-            sb.open("https://www.delta.com/")
-            sb.sleep(2)
+            # Go straight to the real login page and pre-fill credentials, matching
+            # fetch_data() -- opening the plain homepage (the previous approach)
+            # left the user on a page with no visible login form and nothing
+            # pre-filled, with no indication of what to do next.
+            sb.open("https://www.delta.com/skymiles/login")
+            sb.sleep(3)
             self._dismiss_cookie_banners(sb)
-            
-            # Wait for user to log in and land on the profile dashboard
-            # Example Delta dashboard URL fragment
-            print("Please log in manually. Waiting for the dashboard URL...")
+
             try:
-                # We can poll the URL to see if it changes to a profile URL
+                if sb.is_element_visible("input#userId-input"):
+                    sb.type("input#userId-input", username)
+                    sb.type("input#password-input", password)
+            except Exception as e:
+                print(f"Error pre-filling Delta credentials: {e}")
+
+            # Wait for the user to leave the login page. Requiring a specific
+            # post-login URL (the previous approach) doesn't work reliably --
+            # reported live: after a real login, Delta redirected back to the
+            # plain homepage rather than any profile/dashboard URL, which never
+            # matched, so the loop just timed out silently. Leaving the login
+            # page at all is a much weaker but more reliable signal; the actual
+            # overview page is force-navigated to unconditionally afterward,
+            # matching fetch_data()'s own reliable pattern.
+            print("Please log in manually. Waiting for login to complete...")
+            success = False
+            try:
                 for _ in range(60):  # Wait up to 5 minutes
-                    current_url = sb.get_current_url()
-                    if "myprofile" in current_url.lower() or "mydelta" in current_url.lower():
-                        print(f"Detected dashboard URL: {current_url}")
+                    current_url = sb.get_current_url().lower()
+                    if "skymiles/login" not in current_url:
+                        print(f"Left login page, now at: {current_url}")
                         sb.sleep(3) # allow page to load
+                        success = True
                         break
                     sb.sleep(5)
             except Exception as e:
                 print(f"Interactive login wait interrupted: {e}")
+
+            if not success:
+                return None
+
+            try:
+                # Wherever login redirected to isn't necessarily the scrapeable
+                # balance page, so navigate to the overview page directly,
+                # matching fetch_data()'s fallback.
+                current_url = sb.get_current_url().lower()
+                if "myskymiles" not in current_url and "myprofile" not in current_url:
+                    print("Navigating to overview page directly...")
+                    sb.open("https://www.delta.com/myskymiles/overview")
+                    sb.sleep(5)
+                    self._dismiss_cookie_banners(sb)
+
+                sb.sleep(5)  # Allow data to load
+                html = sb.get_page_source()
+                balance, status = self._extract_balance_status(html)
+            except PluginError:
+                raise
+            except Exception as e:
+                raise PluginError(f"Logged in successfully, but failed to read SkyMiles balance: {e}")
+
+            if balance is None:
+                raise PluginError("Logged in successfully, but could not find SkyMiles balance on the Delta dashboard.")
+
+            return {
+                "balance": balance,
+                "status": status,
+                "expiration_date": None
+            }

--- a/plugins/hyatt.py
+++ b/plugins/hyatt.py
@@ -282,7 +282,7 @@ class WorldofHyattPlugin(ProviderPlugin):
             pass
         return None
 
-    def interactive_login(self, username: str, password: str, profile_dir: str = None, **kwargs) -> None:
+    def interactive_login(self, username: str, password: str, profile_dir: str = None, **kwargs) -> Optional[Dict[str, Any]]:
         """
         Opens an interactive browser window for the user to resolve MFA.
         Uses clean profiles and saves cookies dynamically to bypass Akamai bot blocks.
@@ -333,13 +333,49 @@ class WorldofHyattPlugin(ProviderPlugin):
                 except Exception:
                     pass
                 
-                # Wait up to 5 minutes for the user to resolve MFA/captcha and reach the dashboard
-                try:
-                    sb.wait_for_element_visible('[data-locator="points-balance"]', timeout=300)
-                    sb.sleep(5) 
-                except Exception:
+                # Wait up to 5 minutes for the user to resolve MFA/captcha and leave
+                # the sign-in page. Waiting directly for the points-balance locator
+                # (the previous approach) could time out entirely: Hyatt's natural
+                # post-login redirect doesn't reliably land on account-overview, the
+                # only page that locator actually appears on -- fetch_data() always
+                # force-navigates there explicitly rather than trusting the redirect.
+                left_sign_in = False
+                for _ in range(60):
+                    try:
+                        if "sign-in" not in sb.get_current_url().lower():
+                            left_sign_in = True
+                            break
+                    except Exception:
+                        pass
+                    sb.sleep(5)
+                if not left_sign_in:
                     raise PluginError("Interactive login timed out after 5 minutes or dashboard failed to load.")
-                
+                sb.sleep(3)
+
+                # Force open account-overview regardless of where the post-login
+                # redirect landed, matching fetch_data()'s reliable navigation.
+                if "profile" not in sb.get_current_url():
+                    print("Opening Hyatt account-overview page...")
+                    sb.open("https://www.hyatt.com/profile/account-overview")
+                    sb.sleep(5)
+
+                balance, status = self._extract_data(sb)
+                if balance is None:
+                    # Fallback refresh in case of slow API render, matching fetch_data().
+                    sb.refresh()
+                    sb.sleep(6)
+                    balance, status = self._extract_data(sb)
+                if balance is None:
+                    raise PluginError("Logged in successfully, but could not find points on Hyatt account overview page.")
+
+                result = {
+                    "balance": balance,
+                    "status": status or "Unknown",
+                    "expiration_date": None,
+                    "certificates": []
+                }
+                result["last_activity_date"] = self._fetch_last_activity_date(sb)
+
                 # Save cookies dynamically
                 if cookie_file:
                     try:
@@ -349,7 +385,9 @@ class WorldofHyattPlugin(ProviderPlugin):
                         print(f"Saved interactive login session cookies to {cookie_file}")
                     except Exception as save_err:
                         print(f"Failed to save cookies after interactive login: {save_err}")
-                        
+
+                return result
+
         except Exception as e:
             if cookie_file and os.path.exists(cookie_file):
                 print("Interactive login failed. Purging session cookies...")

--- a/plugins/jal.py
+++ b/plugins/jal.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Optional, Tuple
 from .base import ProviderPlugin, PluginError, InteractionRequiredError, get_sb_kwargs
 from seleniumbase import SB
 from bs4 import BeautifulSoup
@@ -49,8 +49,10 @@ class JAPANAirlinesPlugin(ProviderPlugin):
         return urls.get(region, "https://www121.jal.co.jp/JmbWeb/JR/JmbTop_en.do")
 
     def _regional_homepage(self, region: str) -> str:
-        urls = {"AR": "https://www.jal.co.jp/ar/en/", "ER": "https://www.jal.co.jp/er/en/",
-                "SR": "https://www.jal.co.jp/sr/en/"}
+        # All three confirmed live -- JAL migrated from the old /ar/en/, /er/en/,
+        # /sr/en/ region-code paths to locale-style codes (en-us, en-gb, en-sg).
+        urls = {"AR": "https://www.jal.co.jp/en-us/", "ER": "https://www.jal.co.jp/en-gb/",
+                "SR": "https://www.jal.co.jp/en-sg/"}
         return urls.get(region, "https://www.jal.co.jp/jp/en/")
 
     def _dismiss_cookie_banners(self, sb) -> None:
@@ -200,13 +202,26 @@ class JAPANAirlinesPlugin(ProviderPlugin):
             except Exception as e:
                 print(f"Worldwide Sites dropdown fallback failed: {e}")
 
+        left_worldwide_sites = False
         if clicked:
             for _ in range(15):
                 sb.sleep(1)
-                if "jal.com/index" not in sb.get_current_url().lower():
+                try:
+                    still_ww = "jal.com/index" in sb.get_current_url().lower() or "worldwide sites" in sb.get_title().lower()
+                except Exception:
+                    still_ww = True
+                if not still_ww:
+                    left_worldwide_sites = True
                     break
         sb.sleep(3)
-        return True
+
+        # Only report "handled" if the click/selection actually got us off the
+        # Worldwide Sites page. Returning True unconditionally here caused the
+        # caller to keep re-opening the (possibly stale/redirecting) region start
+        # URL every time this page was detected, producing an infinite bounce
+        # between the Worldwide Sites page and the start URL when the region
+        # selectors no longer match the site's current layout.
+        return left_worldwide_sites
 
     # -------------------------------------------------------------------------
     # Login helpers
@@ -362,6 +377,85 @@ class JAPANAirlinesPlugin(ProviderPlugin):
     # Core: fetch_data
     # -------------------------------------------------------------------------
 
+    def _extract_balance_status_expiration(self, sb) -> Tuple[Optional[int], Optional[str], Optional[Any]]:
+        """
+        Extracts balance/status/expiration_date from whichever JAL page the
+        (already-authenticated) session is currently on -- the modern JMB page or
+        the legacy www121 region page -- clicking through to the mileage detail
+        page for expiration in either case.
+        """
+        current_url = sb.get_current_url().lower()
+        on_jmb_page = "jal.co.jp/en/jmb" in current_url
+        on_www121 = sb.is_element_visible("span#JS_121_mileBalance")
+
+        if self.is_auth_url(current_url) or (not on_jmb_page and not on_www121):
+            raise InteractionRequiredError("JAL login required. Please use Interactive Login.")
+
+        soup = BeautifulSoup(sb.get_page_source(), "html.parser")
+
+        if on_jmb_page:
+            balance, status = self._parse_jmb_page(soup)
+            expiration_date = None
+            try:
+                clicked = sb.execute_script("""
+                    const a = Array.from(document.querySelectorAll('a')).find(el => {
+                        const href = (el.getAttribute('href') || '').toLowerCase();
+                        const text = (el.textContent || '').toLowerCase();
+                        return href.includes('mile') || text.includes('expir') || text.includes('detail');
+                    });
+                    if (a) { a.click(); return true; }
+                    return false;
+                """)
+                if clicked:
+                    sb.sleep(5)
+                    expiration_date = self.extract_expiration_date(
+                        BeautifulSoup(sb.get_page_source(), "html.parser"))
+            except Exception:
+                pass
+        else:
+            sb.wait_for_element_visible("span#JS_121_mileBalance", timeout=20)
+            sb.sleep(3)
+            soup = BeautifulSoup(sb.get_page_source(), "html.parser")
+
+            balance_el = soup.find(id="JS_121_mileBalance")
+            if not balance_el:
+                raise PluginError("Could not retrieve mileage balance from JAL.")
+            balance = int(re.sub(r"\D", "", balance_el.text.strip()) or 0)
+
+            status_el = soup.find(id="JS_jmbStatusNameText")
+            status = self._normalize_status(status_el.text if status_el else "")
+
+            # Navigate to mileage detail page for expiration
+            try:
+                if not sb.execute_script(
+                    'const f = document.querySelector(\'form[name="mileDetailFrm"]\');'
+                    'if (f) { f.submit(); return true; } return false;'
+                ):
+                    sb.execute_script("""
+                        let el = Array.from(document.querySelectorAll('a')).find(a => {
+                            const t = (a.textContent || '').toLowerCase();
+                            const h = a.getAttribute('href') || '';
+                            return t.includes('mile') && (h.includes('javascript') || h.includes('CnfMlg'));
+                        });
+                        if (!el) {
+                            const sp = document.querySelector('span#JS_121_mileBalance');
+                            if (sp) el = sp.closest('a');
+                        }
+                        if (el) el.click();
+                    """)
+            except Exception:
+                pass
+
+            try:
+                sb.wait_for_element_visible("table.termmile", timeout=20)
+            except Exception:
+                sb.sleep(5)
+
+            expiration_date = self.extract_expiration_date(
+                BeautifulSoup(sb.get_page_source(), "html.parser"))
+
+        return balance, status, expiration_date
+
     def fetch_data(self, username: str, password: str, profile_dir: str = None, **kwargs) -> Dict[str, Any]:
         region = (kwargs.get("region") or "JR").upper()
         with SB(**get_sb_kwargs(uc=True, headless=False, user_data_dir=profile_dir)) as sb:
@@ -424,76 +518,7 @@ class JAPANAirlinesPlugin(ProviderPlugin):
                         continue
                     break
 
-                current_url = sb.get_current_url().lower()
-                on_jmb_page = "jal.co.jp/en/jmb" in current_url
-                on_www121   = sb.is_element_visible("span#JS_121_mileBalance")
-
-                if self.is_auth_url(current_url) or (not on_jmb_page and not on_www121):
-                    raise InteractionRequiredError("JAL login required. Please use Interactive Login.")
-
-                soup = BeautifulSoup(sb.get_page_source(), "html.parser")
-
-                if on_jmb_page:
-                    balance, status = self._parse_jmb_page(soup)
-                    expiration_date = None
-                    try:
-                        clicked = sb.execute_script("""
-                            const a = Array.from(document.querySelectorAll('a')).find(el => {
-                                const href = (el.getAttribute('href') || '').toLowerCase();
-                                const text = (el.textContent || '').toLowerCase();
-                                return href.includes('mile') || text.includes('expir') || text.includes('detail');
-                            });
-                            if (a) { a.click(); return true; }
-                            return false;
-                        """)
-                        if clicked:
-                            sb.sleep(5)
-                            expiration_date = self.extract_expiration_date(
-                                BeautifulSoup(sb.get_page_source(), "html.parser"))
-                    except Exception:
-                        pass
-                else:
-                    sb.wait_for_element_visible("span#JS_121_mileBalance", timeout=20)
-                    sb.sleep(3)
-                    soup = BeautifulSoup(sb.get_page_source(), "html.parser")
-
-                    balance_el = soup.find(id="JS_121_mileBalance")
-                    if not balance_el:
-                        raise PluginError("Could not retrieve mileage balance from JAL.")
-                    balance = int(re.sub(r"\D", "", balance_el.text.strip()) or 0)
-
-                    status_el = soup.find(id="JS_jmbStatusNameText")
-                    status = self._normalize_status(status_el.text if status_el else "")
-
-                    # Navigate to mileage detail page for expiration
-                    try:
-                        if not sb.execute_script(
-                            'const f = document.querySelector(\'form[name="mileDetailFrm"]\');'
-                            'if (f) { f.submit(); return true; } return false;'
-                        ):
-                            sb.execute_script("""
-                                let el = Array.from(document.querySelectorAll('a')).find(a => {
-                                    const t = (a.textContent || '').toLowerCase();
-                                    const h = a.getAttribute('href') || '';
-                                    return t.includes('mile') && (h.includes('javascript') || h.includes('CnfMlg'));
-                                });
-                                if (!el) {
-                                    const sp = document.querySelector('span#JS_121_mileBalance');
-                                    if (sp) el = sp.closest('a');
-                                }
-                                if (el) el.click();
-                            """)
-                    except Exception:
-                        pass
-
-                    try:
-                        sb.wait_for_element_visible("table.termmile", timeout=20)
-                    except Exception:
-                        sb.sleep(5)
-
-                    expiration_date = self.extract_expiration_date(
-                        BeautifulSoup(sb.get_page_source(), "html.parser"))
-
+                balance, status, expiration_date = self._extract_balance_status_expiration(sb)
                 return {"balance": balance, "status": status, "expiration_date": expiration_date}
 
             except InteractionRequiredError:
@@ -505,12 +530,22 @@ class JAPANAirlinesPlugin(ProviderPlugin):
     # Core: interactive_login
     # -------------------------------------------------------------------------
 
-    def interactive_login(self, username: str, password: str, profile_dir: str = None, **kwargs) -> None:
+    def interactive_login(self, username: str, password: str, profile_dir: str = None, **kwargs) -> Optional[Dict[str, Any]]:
         region = (kwargs.get("region") or "JR").upper()
         with SB(**get_sb_kwargs(uc=True, headless=False, user_data_dir=profile_dir)) as sb:
             try:
                 for attempt in range(2):
                     print(f"Interactive login attempt {attempt + 1}, region: {region}")
+                    # Establish a normal browsing session on the regional homepage
+                    # before attempting the deep JMB member-area link -- cold-opening
+                    # an authenticated-area URL directly appears to trigger JAL's
+                    # region-detection/Worldwide-Sites redirect defensively, the same
+                    # anti-bot-style pattern other airline sites in this codebase
+                    # (British Airways, Avianca, Virgin Atlantic) already work around
+                    # by visiting the homepage first.
+                    sb.open(self._regional_homepage(region))
+                    sb.sleep(3)
+                    self._dismiss_cookie_banners(sb)
                     sb.open(self._start_url(region))
                     sb.sleep(3)
 
@@ -551,9 +586,18 @@ class JAPANAirlinesPlugin(ProviderPlugin):
                             sb.sleep(5)
                             break
                         if self._handle_worldwide_sites(sb, region):
-                            sb.sleep(3)
-                            sb.open(self._start_url(region))
-                            sb.sleep(5)
+                            # Confirmed via live logs: selecting a region here means
+                            # login already succeeded (Worldwide Sites is JAL's normal
+                            # one-time post-login "confirm your region" step, not a
+                            # bot-reject). The regional homepage it lands on already
+                            # shows the mileage balance in its header using the same
+                            # element (span#JS_121_mileBalance) as logged_in_sel, so no
+                            # further navigation is needed at all -- just let the next
+                            # loop iteration's own top-of-loop check detect it there.
+                            # Re-opening the deep SSO login link here (the previous
+                            # approach) forces a brand new authentication handshake,
+                            # which is what was actually causing the observed bounce
+                            # back to the region picker.
                             continue
                         correct_region = self._detect_region_mismatch(sb)
                         if correct_region and correct_region != region:
@@ -569,3 +613,21 @@ class JAPANAirlinesPlugin(ProviderPlugin):
 
             except Exception as e:
                 print(f"Interactive login interrupted: {e}")
+                return None
+
+            # The inner wait loop above can also exit by exhausting its 60 iterations
+            # without ever detecting a logged-in state, so verify before extracting.
+            logged_in_sel = "span#JS_121_mileBalance"
+            try:
+                current_url = sb.get_current_url().lower()
+            except Exception:
+                return None
+            if not (sb.is_element_visible(logged_in_sel) and not self.is_auth_url(current_url)):
+                return None
+
+            try:
+                balance, status, expiration_date = self._extract_balance_status_expiration(sb)
+            except Exception as e:
+                raise PluginError(f"Logged in successfully, but failed to read JAL mileage balance: {e}")
+
+            return {"balance": balance, "status": status, "expiration_date": expiration_date}

--- a/tests/test_apis_and_plugins.py
+++ b/tests/test_apis_and_plugins.py
@@ -1450,6 +1450,39 @@ class TestAPIsAndPlugins(unittest.TestCase):
             with self.assertRaises(InteractionRequiredError):
                 plugin.fetch_data("user", "pass")
 
+    def test_alaska_extract_balance_status_atmos_tier_names(self):
+        """
+        Alaska rebranded Mileage Plan's MVP tiers to Atmos Rewards (Atmos Silver/
+        Gold/Platinum/Titanium). _extract_balance_status() must report the actual
+        tier name rather than bucketing everyone into a generic "Atmos Member",
+        while still recognizing legacy "MVP Gold 75K/100K" wording for
+        grandfathered members.
+        """
+        plugin = plugin_manager.get_plugin('alaska')
+        self.assertIsNotNone(plugin)
+
+        cases = [
+            ("<div class='points-value'>5000</div><span>Atmos Silver</span>", "Atmos Silver"),
+            ("<div class='points-value'>5000</div><span>Atmos Gold</span>", "Atmos Gold"),
+            ("<div class='points-value'>5000</div><span>Atmos Platinum</span>", "Atmos Platinum"),
+            ("<div class='points-value'>5000</div><span>Atmos Titanium</span>", "Atmos Titanium"),
+            ("<div class='points-value'>5000</div><span>MVP Gold</span>", "MVP Gold"),
+            ("<div class='points-value'>5000</div><span>MVP Gold 75K</span>", "MVP Gold 75K"),
+            ("<div class='points-value'>5000</div><span>MVP Gold 100K</span>", "MVP Gold 100K"),
+            ("<div class='points-value'>5000</div><span>MVP</span>", "MVP"),
+            ("<div class='points-value'>5000</div><span>Atmos™ Member</span>", "Atmos Member"),
+        ]
+        for html, expected_status in cases:
+            balance, status = plugin._extract_balance_status(html)
+            self.assertEqual(balance, 5000)
+            self.assertEqual(status, expected_status, f"Failed for html: {html}")
+
+        # The strongest tier mentioned anywhere on the page should win, even if a
+        # weaker mention (e.g. from marketing copy) appears elsewhere.
+        html_mixed = "<div class='points-value'>5000</div><span>MVP</span><span>Atmos Titanium</span>"
+        balance, status = plugin._extract_balance_status(html_mixed)
+        self.assertEqual(status, "Atmos Titanium")
+
     def test_jal_expiration_date_extraction(self):
         plugin = plugin_manager.get_plugin('jal')
         self.assertIsNotNone(plugin)
@@ -2322,6 +2355,91 @@ class TestAPIsAndPlugins(unittest.TestCase):
         self.assertEqual(account.balance, 1000)
         self.assertEqual(account.status, "Bronze")
         self.assertEqual(account.last_fetch_status, "SUCCESS")
+
+    # ==========================================
+    # Interactive-login "returns data directly" coverage for the "hard" plugins
+    # (Alaska, Delta, Hyatt, JAL), which don't extract any page data during
+    # interactive_login() by default -- addressing review feedback requesting
+    # test cases for this PR, mirroring the per-plugin pattern used for the
+    # assisted-mode plugins in PR #120.
+    # ==========================================
+
+    def _mock_sb(self, current_url="https://example.com/", page_source="<html></html>"):
+        """Builds a MagicMock simulating an `sb` instance plus the context manager
+        wrapper matching `with SB(...) as sb:` usage in interactive_login()."""
+        from unittest.mock import MagicMock
+        mock_sb = MagicMock()
+        mock_sb.get_current_url.return_value = current_url
+        mock_sb.get_page_source.return_value = page_source
+        mock_sb.is_element_visible.return_value = False
+        mock_sb.is_element_present.return_value = False
+
+        mock_context = MagicMock()
+        mock_context.__enter__.return_value = mock_sb
+        mock_context.__exit__.return_value = False
+        return mock_sb, mock_context
+
+    def test_alaska_interactive_login_returns_data(self):
+        from unittest.mock import patch
+        plugin = plugin_manager.get_plugin('alaska')
+        mock_sb, mock_context = self._mock_sb(
+            current_url="https://www.alaskaair.com/atmosrewards/account/overview/"
+        )
+
+        with patch('plugins.alaska.SB', return_value=mock_context), \
+             patch.object(plugin, 'get_consistent_user_agent', return_value='test-agent'), \
+             patch.object(plugin, '_extract_balance_status', return_value=(12000, 'Atmos Gold')):
+            result = plugin.interactive_login('user', 'pass', profile_dir=None)
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result['balance'], 12000)
+        self.assertEqual(result['status'], 'Atmos Gold')
+
+    def test_delta_interactive_login_returns_data(self):
+        from unittest.mock import patch
+        plugin = plugin_manager.get_plugin('delta')
+        mock_sb, mock_context = self._mock_sb(current_url="https://www.delta.com/myskymiles/overview")
+
+        with patch('plugins.delta.SB', return_value=mock_context), \
+             patch.object(plugin, '_extract_balance_status', return_value=(20000, 'Diamond Medallion')):
+            result = plugin.interactive_login('user', 'pass', profile_dir=None)
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result['balance'], 20000)
+        self.assertEqual(result['status'], 'Diamond Medallion')
+
+    def test_hyatt_interactive_login_returns_data(self):
+        from unittest.mock import patch
+        plugin = plugin_manager.get_plugin('hyatt')
+        mock_sb, mock_context = self._mock_sb(current_url="https://www.hyatt.com/profile/account-overview")
+        # Hyatt's login-form-detection loop gates on this selector being visible
+        # before it will even attempt to proceed past the sign-in page.
+        mock_sb.is_element_visible.return_value = True
+
+        with patch('plugins.hyatt.SB', return_value=mock_context), \
+             patch.object(plugin, '_extract_data', return_value=(9000, 'Globalist')), \
+             patch.object(plugin, '_fetch_last_activity_date', return_value=None):
+            result = plugin.interactive_login('user', 'pass', profile_dir=None)
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result['balance'], 9000)
+        self.assertEqual(result['status'], 'Globalist')
+
+    def test_jal_interactive_login_returns_data(self):
+        from unittest.mock import patch
+        plugin = plugin_manager.get_plugin('jal')
+        mock_sb, mock_context = self._mock_sb(current_url="https://www.jal.co.jp/jp/en/")
+        # JAL's region-detection loop gates on the mileage-balance element being
+        # visible to treat login as already complete.
+        mock_sb.is_element_visible.return_value = True
+
+        with patch('plugins.jal.SB', return_value=mock_context), \
+             patch.object(plugin, '_extract_balance_status_expiration', return_value=(30000, 'JGC Premier', None)):
+            result = plugin.interactive_login('user', 'pass', profile_dir=None)
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result['balance'], 30000)
+        self.assertEqual(result['status'], 'JGC Premier')
 
     def test_dashboard_renders_generic_sync_failure_both_options(self):
         # Create an account with a generic/vague failure


### PR DESCRIPTION
## Summary
Completes the remaining "hard" plugins that don't extract any page data during `interactive_login()` at all — only a URL/element check to detect "logged in" — so a bare return of already-computed data wasn't possible the way it was for other plugins. Ported each plugin's own `fetch_data()` extraction into `interactive_login()`, and fixed several real bugs found via live testing along the way.

**Data capture**
- `alaska.py`, `delta.py`: extracted the previously-inlined balance/status parsing into a shared `_extract_balance_status()` method used by both `fetch_data()` and `interactive_login()`.
- `hyatt.py`: already had the right helper methods; `interactive_login()` just wasn't calling them. Wired them up — `calculate_expiration()` depends entirely on `last_activity_date` with no scraped-expiration-date fallback, so omitting it would have silently shown "Never Expires" incorrectly.
- `jal.py`: extracted the branchy post-login extraction (modern JMB page vs. legacy region page, each needing a click-through to a separate mileage-detail page for expiration) into a shared `_extract_balance_status_expiration()` method.

**Cancellation**
- `app.py`: the interactive-login route now checks a shared `is_cancelled()` flag immediately after `interactive_login()` returns, so a cancelled run can't fall through to an automatic `fetch_data()` fallback in a new, unprotected browser session — some plugins' own broad `except` blocks swallow the cancellation error and return `None`, which is otherwise indistinguishable from "this plugin can't scrape mid-login, please fall back".
- `plugins/base.py`: `cancel_active_driver()` also force-kills any lingering Chrome process tied to the account's browser profile, and a shared cancellation flag stops a cancelled session from making further Selenium calls at all.

**JAL**
- Fixed a real infinite loop: `interactive_login()` was re-opening the deep SSO login link every time the Worldwide Sites region-picker was handled, even after a successful click — forcing a brand new authentication handshake that bounced back to the region picker. Selecting a region there only happens after login already succeeded (JAL's normal one-time post-login "confirm your region" step, not a bot-reject), so no re-navigation is needed afterward.
- Updated all three regional homepage URLs (Americas, Europe/Middle East/Africa, Asia/Oceania), confirmed live — JAL migrated from `/ar/en/`, `/er/en/`, `/sr/en/` region-code paths to locale-style codes (`en-us`, `en-gb`, `en-sg`).

**Hyatt and Delta**
- Both plugins' `interactive_login()` never actually navigated to the real scrapeable overview/dashboard page the way `fetch_data()` does. Both now force-navigate there directly, using a weaker but reliable "did we leave the previous page" signal, matching `fetch_data()`'s own pattern.
- Delta's `interactive_login()` also never opened the actual login page or pre-filled credentials, leaving the user on the plain homepage with no visible form.

## Test plan
- [x] Full test suite passes (168 passed, 3 skipped)
- [x] All 31 plugins load cleanly via the plugin manager
- [x] Manually verified end-to-end against live accounts for all four plugins (Alaska, Delta, Hyatt, JAL), including cancel-mid-login behavior