### PR TITLE
feat(hilton): sync free night certificates

### DIFF
--- a/plugins/hilton.py
+++ b/plugins/hilton.py
@@ -226,6 +226,47 @@ class HiltonHonorsPlugin(ProviderPlugin):
             
         return balance, status, last_activity_date
 
+    def _parse_free_night_awards(self, html: str) -> list:
+        """Extracts unredeemed Free Night Certificates from the Rewards section of the my-account page."""
+        import re
+
+        soup = BeautifulSoup(html, "html.parser")
+        certificates = []
+
+        # Only the "Current rewards" tab (Ready to use / Reserved for upcoming stay) holds
+        # certificates still available to use; the "Used rewards" tab is intentionally skipped.
+        current_tab = soup.find(id="tab-panel-currentRewards")
+        if not current_tab:
+            return certificates
+
+        for card in current_tab.find_all("div", attrs={"data-testid": "award-card-FNC"}):
+            name_el = card.find("h4")
+            name = name_el.get_text(strip=True) if name_el else "Hilton Free Night Certificate"
+
+            card_text = card.get_text(" ", strip=True)
+
+            details = {}
+            cert_match = re.search(r'Certificate\s*#\s*([•\d\s]+\d)', card_text)
+            if cert_match:
+                details["Certificate #"] = re.sub(r'\s+', ' ', cert_match.group(1)).strip()
+
+            expiration_date = None
+            valid_match = re.search(r'Valid until\s+(\d{1,2}/\d{1,2}/\d{4})', card_text)
+            if valid_match:
+                try:
+                    dt = datetime.strptime(valid_match.group(1), "%m/%d/%Y")
+                    expiration_date = dt.strftime("%Y-%m-%d")
+                except ValueError:
+                    pass
+
+            certificates.append({
+                "name": name,
+                "expiration_date": expiration_date,
+                "details": details
+            })
+
+        return certificates
+
     def _fill_login_form(self, sb, username: str, password: str, auto_submit: bool = True) -> None:
         """Fills the Hilton login form and submits."""
         user_selector = "input[name='username']"
@@ -283,13 +324,23 @@ class HiltonHonorsPlugin(ProviderPlugin):
                     self._fill_login_form(sb, username, password, auto_submit=True)
                     sb.sleep(10)
 
-                # 2. Always navigate to the activity page to extract transactions/stays & last activity date
+                # 2. Capture Free Night Certificates immediately if login already landed on the account page,
+                # to avoid an extra round-trip back to it later
                 curr_url = sb.get_current_url()
+                certificates_captured = False
+                if "my-account" in curr_url:
+                    try:
+                        result["certificates"] = self._parse_free_night_awards(sb.get_page_source())
+                        certificates_captured = True
+                    except Exception:
+                        pass
+
+                # 3. Always navigate to the activity page to extract transactions/stays & last activity date
                 if "activity" not in curr_url:
                     sb.open("https://www.hilton.com/en/hilton-honors/guest/activity/")
                     sb.sleep(8)
 
-                # 3. Extract data from activity page
+                # 4. Extract data from activity page
                 balance, status, last_activity = self._extract_data(sb)
                 if balance is None:
                     # Fallback refresh in case of slow API response rendering
@@ -297,7 +348,7 @@ class HiltonHonorsPlugin(ProviderPlugin):
                     sb.sleep(8)
                     balance, status, last_activity = self._extract_data(sb)
 
-                # 4. If balance was not found on activity page, fallback to overview / dashboard
+                # 5. If balance was not found on activity page, fallback to overview / dashboard
                 if balance is None:
                     sb.open("https://www.hilton.com/en/hilton-honors/guest/overview/")
                     sb.sleep(8)
@@ -323,7 +374,16 @@ class HiltonHonorsPlugin(ProviderPlugin):
                         "at_risk": True,
                         "reason": "No activity recorded in the last 12 months"
                     }
-                
+
+                # 6. Navigate to the account page to extract Free Night Certificates, if not already captured above
+                if not certificates_captured:
+                    try:
+                        sb.open("https://www.hilton.com/en/hilton-honors/guest/my-account/")
+                        sb.sleep(8)
+                        result["certificates"] = self._parse_free_night_awards(sb.get_page_source())
+                    except Exception:
+                        pass
+
                 return result
                 
         except InteractionRequiredError:

--- a/tests/test_apis_and_plugins.py
+++ b/tests/test_apis_and_plugins.py
@@ -569,6 +569,142 @@ class TestAPIsAndPlugins(unittest.TestCase):
         self.assertEqual(last_act.month, 5)
         self.assertEqual(last_act.day, 15)
 
+    def test_hilton_free_night_award_parsing(self):
+        plugin = plugin_manager.get_plugin('hilton')
+        self.assertIsNotNone(plugin)
+
+        html = """
+        <div id="tab-panel-currentRewards" aria-hidden="false" role="tabpanel" class="w-full">
+          <section>
+            <div data-testid="rewards-available">
+              <h3>Ready to use (1)</h3>
+              <div data-testid="award-card-FNC">
+                <h4>Amex Aspire Anniversary Free Night</h4>
+                <p>Certificate # ••••• 7724</p>
+                <p>Valid until 03/15/2028</p>
+              </div>
+            </div>
+            <div data-testid="no-rewards-reserved">
+              <h3>Reserved for upcoming stay (0)</h3>
+              <p>You haven't used any rewards yet to an upcoming stay.</p>
+            </div>
+          </section>
+        </div>
+        <div id="tab-panel-usedRewards" aria-hidden="true" role="tabpanel" class="w-full hidden">
+          <div data-testid="rewards-used">
+            <h3>Your used rewards (1)</h3>
+            <div data-testid="award-card-FNC">
+              <h4>Sunset Reef, an SLH Hotel</h4>
+              <p>Certificate # ••••• 5061</p>
+              <p>Redeemed 11/02/2025</p>
+            </div>
+          </div>
+        </div>
+        """
+
+        certs = plugin._parse_free_night_awards(html)
+
+        # Only the unredeemed "Ready to use" card should be captured; the used one must be excluded.
+        self.assertEqual(len(certs), 1)
+        cert = certs[0]
+        self.assertEqual(cert["name"], "Amex Aspire Anniversary Free Night")
+        self.assertEqual(cert["expiration_date"], "2028-03-15")
+        self.assertEqual(cert["details"]["Certificate #"], "••••• 7724")
+
+        # No current-rewards tab present at all -> empty list, no crash
+        self.assertEqual(plugin._parse_free_night_awards("<html><body>no rewards section</body></html>"), [])
+
+    def test_hilton_free_night_award_parsing_zero_awards(self):
+        plugin = plugin_manager.get_plugin('hilton')
+        self.assertIsNotNone(plugin)
+
+        html = """
+        <div id="tab-panel-currentRewards" aria-hidden="false" role="tabpanel" class="w-full">
+          <section>
+            <div data-testid="rewards-available">
+              <h3>Ready to use (0)</h3>
+              <p>You don't have any rewards to use right now.</p>
+            </div>
+            <div data-testid="no-rewards-reserved">
+              <h3>Reserved for upcoming stay (0)</h3>
+              <p>You haven't used any rewards yet to an upcoming stay.</p>
+            </div>
+          </section>
+        </div>
+        <div id="tab-panel-usedRewards" aria-hidden="true" role="tabpanel" class="w-full hidden">
+          <div data-testid="rewards-used">
+            <h3>Your used rewards (0)</h3>
+          </div>
+        </div>
+        """
+
+        self.assertEqual(plugin._parse_free_night_awards(html), [])
+
+    def test_hilton_free_night_award_parsing_multiple_awards(self):
+        plugin = plugin_manager.get_plugin('hilton')
+        self.assertIsNotNone(plugin)
+
+        # Two awards with different expiration dates
+        html_different_dates = """
+        <div id="tab-panel-currentRewards" aria-hidden="false" role="tabpanel" class="w-full">
+          <section>
+            <div data-testid="rewards-available">
+              <h3>Ready to use (2)</h3>
+              <div data-testid="award-card-FNC">
+                <h4>Amex Aspire Anniversary Free Night</h4>
+                <p>Certificate # ••••• 1122</p>
+                <p>Valid until 03/15/2028</p>
+              </div>
+              <div data-testid="award-card-FNC">
+                <h4>Amex Surpass Anniversary Free Night</h4>
+                <p>Certificate # ••••• 3344</p>
+                <p>Valid until 09/01/2027</p>
+              </div>
+            </div>
+          </section>
+        </div>
+        """
+
+        certs = plugin._parse_free_night_awards(html_different_dates)
+        self.assertEqual(len(certs), 2)
+        self.assertEqual(certs[0]["name"], "Amex Aspire Anniversary Free Night")
+        self.assertEqual(certs[0]["expiration_date"], "2028-03-15")
+        self.assertEqual(certs[0]["details"]["Certificate #"], "••••• 1122")
+        self.assertEqual(certs[1]["name"], "Amex Surpass Anniversary Free Night")
+        self.assertEqual(certs[1]["expiration_date"], "2027-09-01")
+        self.assertEqual(certs[1]["details"]["Certificate #"], "••••• 3344")
+
+        # Two awards sharing the same expiration date must both be kept, not deduplicated
+        html_same_date = """
+        <div id="tab-panel-currentRewards" aria-hidden="false" role="tabpanel" class="w-full">
+          <section>
+            <div data-testid="rewards-available">
+              <h3>Ready to use (2)</h3>
+              <div data-testid="award-card-FNC">
+                <h4>Amex Aspire Anniversary Free Night</h4>
+                <p>Certificate # ••••• 5566</p>
+                <p>Valid until 12/25/2027</p>
+              </div>
+              <div data-testid="award-card-FNC">
+                <h4>Amex Aspire Anniversary Free Night</h4>
+                <p>Certificate # ••••• 7788</p>
+                <p>Valid until 12/25/2027</p>
+              </div>
+            </div>
+          </section>
+        </div>
+        """
+
+        certs_same_date = plugin._parse_free_night_awards(html_same_date)
+        self.assertEqual(len(certs_same_date), 2)
+        self.assertEqual(certs_same_date[0]["expiration_date"], "2027-12-25")
+        self.assertEqual(certs_same_date[1]["expiration_date"], "2027-12-25")
+        # Distinct certificate numbers confirm these are two separate awards, not one duplicated
+        self.assertNotEqual(
+            certs_same_date[0]["details"]["Certificate #"],
+            certs_same_date[1]["details"]["Certificate #"]
+        )
+
     def test_milemoa_hilton_user_complaint_mock_page(self):
         """
         Reproduces the exact user complaint from MileMoa / Issue #113:


### PR DESCRIPTION
## Summary
Hilton Honors free night certificates (e.g. from Amex Aspire card anniversary nights) aren't currently synced, unlike United's club one-time passes which already use the generic `Certificate` model. This adds the same capability for Hilton.

- Added `_parse_free_night_awards()` to `plugins/hilton.py`, which parses the "Rewards" section of `hilton.com/en/hilton-honors/guest/my-account/`. It reads the "Current rewards" tab (unredeemed certificates — both "Ready to use" and any future "Reserved for upcoming stay" cards, since they share the same `award-card-FNC` markup) and deliberately skips the "Used rewards" tab. For each card it extracts the name, masked certificate number, and expiration date, returning the same `{name, expiration_date, details}` shape the existing `Certificate` sync logic in `app.py` already consumes — no changes needed there.
- `fetch_data()` now visits the my-account page to populate `result["certificates"]`. Since Hilton's login flow lands directly on that page for some accounts, certificates are captured there immediately (before navigating to the activity page for balance) to avoid a redundant extra page load back to my-account afterward.

## Test plan
- [x] Added `test_hilton_free_night_award_parsing`, covering: an active certificate is captured with correct name/date/code, a redeemed certificate in the "Used rewards" tab is correctly excluded, and no current-rewards tab present returns an empty list without error.
- [x] Full test suite passes (170 passed, 3 skipped)
- [x] Manually verified end-to-end against a live account via both "Sync Now" and the my-account page layout