### PR TITLE
fix(ci): prevent macOS pytest hang on Chrome binary detection and add CI timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
   test:
     name: pytest (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
@@ -38,4 +39,4 @@ jobs:
           pip install pytest "setuptools<81"
 
       - name: Run tests
-        run: pytest -q
+        run: pytest -v --durations=10

--- a/plugins/base.py
+++ b/plugins/base.py
@@ -52,34 +52,7 @@ def get_chrome_binary() -> str | None:
     if system == "Darwin":
         import subprocess
 
-        # 1. Proactively query Launch Services via osascript (most reliable)
-        try:
-            cmd = ["osascript", "-e", 'POSIX path of (path to application "Google Chrome")']
-            app_path = subprocess.check_output(cmd, stderr=subprocess.DEVNULL).decode("utf-8").strip()
-            if app_path:
-                # Strip any trailing slash first
-                app_path = app_path.rstrip("/")
-                binary_path = f"{app_path}/Contents/MacOS/Google Chrome"
-                if os.path.isfile(binary_path) and os.access(binary_path, os.X_OK):
-                    return binary_path
-        except Exception:
-            pass
-
-        # 2. Query Spotlight via mdfind as a second dynamic search option
-        try:
-            cmd = ["mdfind", "kMDItemCFBundleIdentifier == 'com.google.Chrome'"]
-            output = subprocess.check_output(cmd, stderr=subprocess.DEVNULL).decode("utf-8").strip()
-            if output:
-                for line in output.splitlines():
-                    app_path = line.strip()
-                    if app_path:
-                        app_path = app_path.rstrip("/")
-                        binary_path = f"{app_path}/Contents/MacOS/Google Chrome"
-                        if os.path.isfile(binary_path) and os.access(binary_path, os.X_OK):
-                            return binary_path
-        except Exception:
-            pass
-
+        # 1. Check well-known installation paths first (instant, non-invasive, no subprocess)
         candidates = [
             # Standard installation in /Applications (most common)
             "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
@@ -94,6 +67,34 @@ def get_chrome_binary() -> str | None:
         for path in candidates:
             if os.path.isfile(path) and os.access(path, os.X_OK):
                 return path
+
+        # 2. Query Spotlight via mdfind as dynamic search option (fast, never launches app)
+        try:
+            cmd = ["mdfind", "kMDItemCFBundleIdentifier == 'com.google.Chrome'"]
+            output = subprocess.check_output(cmd, stderr=subprocess.DEVNULL, timeout=3).decode("utf-8").strip()
+            if output:
+                for line in output.splitlines():
+                    app_path = line.strip()
+                    if app_path:
+                        app_path = app_path.rstrip("/")
+                        binary_path = f"{app_path}/Contents/MacOS/Google Chrome"
+                        if os.path.isfile(binary_path) and os.access(binary_path, os.X_OK):
+                            return binary_path
+        except Exception:
+            pass
+
+        # 3. Query Launch Services via osascript as a fallback (with strict timeout)
+        try:
+            cmd = ["osascript", "-e", 'POSIX path of (path to application "Google Chrome")']
+            app_path = subprocess.check_output(cmd, stderr=subprocess.DEVNULL, timeout=3).decode("utf-8").strip()
+            if app_path:
+                # Strip any trailing slash first
+                app_path = app_path.rstrip("/")
+                binary_path = f"{app_path}/Contents/MacOS/Google Chrome"
+                if os.path.isfile(binary_path) and os.access(binary_path, os.X_OK):
+                    return binary_path
+        except Exception:
+            pass
 
     elif system == "Windows":
         import os

--- a/tests/test_chrome_binary_detection.py
+++ b/tests/test_chrome_binary_detection.py
@@ -25,6 +25,7 @@ class TestGetChromeBinary(unittest.TestCase):
         """Returns the standard /Applications path when Chrome is installed there."""
         standard = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
         with patch("platform.system", return_value="Darwin"), \
+             patch("subprocess.check_output", side_effect=AssertionError("subprocess should not be called")), \
              patch("os.path.isfile", return_value=True), \
              patch("os.access", return_value=True):
             result = get_chrome_binary()
@@ -44,6 +45,7 @@ class TestGetChromeBinary(unittest.TestCase):
             return path == user_path
 
         with patch("platform.system", return_value="Darwin"), \
+             patch("subprocess.check_output", side_effect=AssertionError("subprocess should not be called")), \
              patch("os.path.isfile", side_effect=fake_isfile), \
              patch("os.access", side_effect=fake_access):
             result = get_chrome_binary()
@@ -60,13 +62,14 @@ class TestGetChromeBinary(unittest.TestCase):
             return path == chromium_path
 
         with patch("platform.system", return_value="Darwin"), \
+             patch("subprocess.check_output", side_effect=AssertionError("subprocess should not be called")), \
              patch("os.path.isfile", side_effect=fake_isfile), \
              patch("os.access", side_effect=fake_access):
             result = get_chrome_binary()
             self.assertEqual(result, chromium_path)
 
     def test_macos_osascript_success(self):
-        """Returns path from osascript when Launch Services resolves it successfully."""
+        """Returns path from osascript when Launch Services resolves it successfully and earlier checks fail."""
         app_path = "/Custom/Applications/Google Chrome.app"
         binary_path = "/Custom/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
 
@@ -76,15 +79,23 @@ class TestGetChromeBinary(unittest.TestCase):
         def fake_access(path, mode):
             return path == binary_path
 
+        def fake_check_output(cmd, **kwargs):
+            if "mdfind" in cmd[0]:
+                raise subprocess.SubprocessError("Failed")
+            elif "osascript" in cmd[0]:
+                return app_path.encode("utf-8")
+            raise ValueError("Unexpected command")
+
+        import subprocess
         with patch("platform.system", return_value="Darwin"), \
-             patch("subprocess.check_output", return_value=app_path.encode("utf-8")), \
+             patch("subprocess.check_output", side_effect=fake_check_output), \
              patch("os.path.isfile", side_effect=fake_isfile), \
              patch("os.access", side_effect=fake_access):
             result = get_chrome_binary()
             self.assertEqual(result, binary_path)
 
     def test_macos_mdfind_success(self):
-        """Returns path from mdfind when osascript fails but Spotlight succeeds."""
+        """Returns path from mdfind when candidate paths fail and Spotlight succeeds."""
         app_path = "/Volumes/Backup/Applications/Google Chrome.app"
         binary_path = "/Volumes/Backup/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
 
@@ -95,10 +106,10 @@ class TestGetChromeBinary(unittest.TestCase):
             return path == binary_path
 
         def fake_check_output(cmd, **kwargs):
-            if "osascript" in cmd[0]:
-                raise subprocess.SubprocessError("Failed")
-            elif "mdfind" in cmd[0]:
+            if "mdfind" in cmd[0]:
                 return app_path.encode("utf-8")
+            elif "osascript" in cmd[0]:
+                raise subprocess.SubprocessError("Failed")
             raise ValueError("Unexpected command")
 
         import subprocess


### PR DESCRIPTION
## Summary

Fixes the issue where pytest on `macos-latest` in GitHub Actions hung indefinitely (exceeding 18 minutes until manually cancelled).

### Root Cause
- In `plugins/base.py`, `get_chrome_binary()` ran `osascript -e 'POSIX path of (path to application "Google Chrome")'` as its first step. In AppleScript, `path to application` sends an AppleEvent to the target app and launches it if it is not currently running.
- On a fresh, headless GitHub Actions macOS runner, Google Chrome had never been launched. Launching Chrome in a non-GUI environment caused Chrome to hang waiting for first-run setup or GUI display.
- `subprocess.check_output` had no timeout, blocking pytest indefinitely.
- In `tests/test_chrome_binary_detection.py`, several tests did not mock `subprocess.check_output`, triggering the live command on macOS runners.

### Changes
1. **`plugins/base.py`**:
   - Reordered macOS Chrome detection to check standard `/Applications` and `~/Applications` paths first via `os.path.isfile` (bypassing subprocesses entirely on standard setups).
   - Placed `mdfind` (Spotlight metadata query, which never launches apps) ahead of `osascript`.
   - Added `timeout=3` to all dynamic subprocess lookups.
2. **`tests/test_chrome_binary_detection.py`**:
   - Patched `subprocess.check_output` across all macOS tests to prevent unit tests from spawning host processes.
3. **`.github/workflows/ci.yml`**:
   - Added `timeout-minutes: 10` to prevent runaway CI runs.
   - Changed `pytest -q` to `pytest -v --durations=10` for detailed logging of test progression.

### Verification
- Ran `TestGetChromeBinary` suite (15 passed in 0.03s).
- Ran full test suite via `python -m pytest -q` (214 passed, 3 skipped in 32.49s).